### PR TITLE
WIP: Recursive sourcing of .tool-versions and small things

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ First, make sure you install and globally activate the most recent direnv
 version:
 
 ```bash
+asdf plugin-add direnv
 asdf install direnv 2.20.0
 asdf global  direnv 2.20.0
 ```

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <hr />
 
 [![Main workflow](https://github.com/asdf-community/asdf-direnv/workflows/Main%20workflow/badge.svg)](https://github.com/asdf-community/asdf-direnv/actions)
-[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/asdf-community/asdf-direnv.svg)](https://isitmaintained.com/project/asdf-community/asdf-direnv 'Average time to resolve an issue')
-[![Percentage of issues still open](https://isitmaintained.com/badge/open/asdf-community/asdf-direnv.svg)](https://isitmaintained.com/project/asdf-community/asdf-direnv 'Percentage of issues still open')
+[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/asdf-community/asdf-direnv.svg)](https://isitmaintained.com/project/asdf-community/asdf-direnv "Average time to resolve an issue")
+[![Percentage of issues still open](https://isitmaintained.com/badge/open/asdf-community/asdf-direnv.svg)](https://isitmaintained.com/project/asdf-community/asdf-direnv "Percentage of issues still open")
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 [![License](https://img.shields.io/github/license/asdf-community/asdf-direnv?color=brightgreen)](https://github.com/asdf-community/asdf-direnv/blob/master/LICENSE)
 
@@ -79,7 +79,8 @@ expected location. Also, no more _reshim_ needed upon `npm install`.
 
 ## Usage
 
-First, make sure you install this plugin, then install and globally activate the most recent direnv version:
+First, make sure you install this plugin, then install and globally activate the
+most recent direnv version:
 
 ```bash
 asdf plugin-add direnv

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ expected location. Also, no more _reshim_ needed upon `npm install`.
 
 ## Usage
 
-First, make sure you install and globally activate the most recent direnv
-version:
+First, make sure you install this plugin, then install and globally activate the most recent direnv version:
 
 ```bash
 asdf plugin-add direnv
@@ -120,7 +119,10 @@ Then on your project root where you have a `.tool-versions` file, create a
 
 ```bash
 source $(asdf which direnv_use_asdf)
-use asdf # this will load your .tool-versions file.
+# this will load your global .tool-versions (optional)
+use asdf $HOME/.tool-versions
+# this will load your local .tool-versions
+use asdf
 ```
 
 Other valid `use asdf` examples:
@@ -135,6 +137,11 @@ use asdf /path/to/other/.tool-versions
 use asdf mill
 watch_file .mill-version
 
+# If you want to load only the .tool-versions file in your current project and ignore
+# all other .tool-versions in parent directories. This also prevents stacking with
+# your global configuration.
+use asdf exclusive
+
 # Or if for some reason you want to explicitly force a particular tool and version
 use asdf rust $ASDF_RUST_VERSION
 ```
@@ -147,9 +154,11 @@ will manage the environment variables for you, for example:
 ```bash
 cd /some/project
 direnv: loading .envrc
-direnv: using asdf /some/project/.tool-versions
+direnv: using asdf ~/some/project/.tool-versions
 direnv: using asdf elixir 1.8.1-otp-21
 direnv: using asdf nodejs 12.6.0
+direnv: using asdf ~/.tool-versions
+direnv: using asdf direnv 2.20.0
 direnv: export +MIX_ARCHIVES +MIX_HOME +NPM_CONFIG_PREFIX ~PATH
 ```
 

--- a/shims/direnv_use_asdf
+++ b/shims/direnv_use_asdf
@@ -67,20 +67,20 @@ _use_tool_versions() {
       return 1
     fi
     # checking whether to proceed recursively.
-    if $1 ; then
+    if $1; then
       _use_tool_versions true "$tool_versions"
     else
-      echo "$tool_versions is used exclusively";
+      echo "$tool_versions is used exclusively"
     fi
   elif $1; then
     local dir
     local file
     dir=$(dirname "$2")
     file=$(basename "$2")
-    while [ "$dir" != "/" ] ; do
+    while [ "$dir" != "/" ]; do
       dir=$(dirname "$dir")
       tool_versions=$(find "$dir" -maxdepth 1 -name "$file")
-      if [ -f "$tool_versions" ];then
+      if [ -f "$tool_versions" ]; then
         use asdf "$tool_versions"
       fi
     done

--- a/shims/direnv_use_asdf
+++ b/shims/direnv_use_asdf
@@ -75,7 +75,7 @@ _load_plugins_env() {
 }
 
 _plugin_env() {
-  direnv dotenv bash <(env)
+  asdf exec direnv dotenv bash <(env)
 }
 
 _plugin_env_bash() {

--- a/shims/direnv_use_asdf
+++ b/shims/direnv_use_asdf
@@ -31,7 +31,34 @@ use_asdf() {
   local plugin
   local version
   if [ -z "$*" ]; then
-    local tool_versions
+    _use_tool_versions true
+  elif [ -f "$1" ]; then
+    _load_plugins_env "$1"
+  elif [ -n "$1" ]; then
+    if [ "$1" == "exclusive" ]; then
+      _use_tool_versions false
+    elif ! (check_if_plugin_exists "$1"); then
+      return 1
+    else
+      _load_plugin_env "$1" "$2"
+    fi
+  else
+    log_error "Invalid args for use asdf. Usage:"
+    log_error "   use asdf TOOL_VERSIONS_FILE"
+    log_error "   use asdf TOOL_NAME [VERSION]"
+    log_error "   use asdf exclusive"
+    return 1
+  fi
+}
+
+## Usage: _use_tool_versions true [/pathto/.tool-versions]
+#
+# $1 should be true for recursive and false for exclusive sourcing.
+# $2 will be passed automatically for iteration over parent directories.
+# Upward folders are searched up to root level "/.tool-versions".
+_use_tool_versions() {
+  local tool_versions
+  if [ -z "$2" ]; then
     tool_versions="$(find_up .tool-versions)"
     if [ -f "$tool_versions" ]; then
       use asdf "$tool_versions"
@@ -39,18 +66,24 @@ use_asdf() {
       log_error "could not find .tool-versions file"
       return 1
     fi
-  elif [ -f "$1" ]; then
-    _load_plugins_env "$1"
-  elif [ -n "$1" ]; then
-    if ! (check_if_plugin_exists "$1"); then
-      return 1
+    # checking whether to proceed recursively.
+    if $1 ; then
+      _use_tool_versions true "$tool_versions"
+    else
+      echo "$tool_versions is used exclusively";
     fi
-    _load_plugin_env "$1" "$2"
-  else
-    log_error "Invalid args for use asdf. Usage:"
-    log_error "   use asdf TOOL_VERSIONS_FILE"
-    log_error "   use asdf TOOL_NAME [VERSION]"
-    return 1
+  elif $1; then
+    local dir
+    local file
+    dir=$(dirname "$2")
+    file=$(basename "$2")
+    while [ "$dir" != "/" ] ; do
+      dir=$(dirname "$dir")
+      tool_versions=$(find "$dir" -maxdepth 1 -name "$file")
+      if [ -f "$tool_versions" ];then
+        use asdf "$tool_versions"
+      fi
+    done
   fi
 }
 


### PR DESCRIPTION
This plugin currently ignores global asdf tools when a local environment is loaded. Without this plugin, all versions are stacked, this pull request implements recursive sourcing of all .tool-versions and adds an option to disable this for specific environments.