### PR TITLE
New feature `use asdf current` to activate current plugins.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v1
 
-      - name: Macos coreutils
+      - name: Macos coreutils # needed by bats-core
         if: matrix.os == 'macOS-latest'
         run: brew install coreutils
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,21 +27,37 @@ jobs:
           direnv --version
 
   test:
-    runs-on: macOS-latest
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest]
+        direnv: [2.20.0]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
 
-      - name: Install asdf
-        run: git clone https://github.com/asdf-vm/asdf.git $HOME/asdf
+      - name: Macos coreutils
+        if: matrix.os == 'macOS-latest'
+        run: brew install coreutils
 
-      - name: Test plugin
+      - name: Install bats
+        run: |
+          git clone https://github.com/bats-core/bats-core.git $HOME/bats-core
+
+      - name: Install asdf
+        run: |
+          git clone https://github.com/asdf-vm/asdf.git $HOME/asdf
+
+      - name: Run tests
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          . $HOME/asdf/asdf.sh
+          export PATH=$HOME/bats-core/bin:$HOME/asdf/bin:$PATH
           asdf plugin-add direnv $GITHUB_WORKSPACE
+          asdf install direnv ${{ matrix.direnv }}
+          asdf global direnv ${{ matrix.direnv }}
           bats test
 
   lint:

--- a/shims/direnv_use_asdf
+++ b/shims/direnv_use_asdf
@@ -15,9 +15,15 @@
 # limitations under the License.
 #
 
+# Load asdf util functions if not already loaded
 if [ -z "$(declare -f -F with_plugin_env)" ]; then
   # shellcheck disable=SC1090 # Can't follow non-constant source. Use a directive to specify location.
   source "$ASDF_DIR/lib/utils.sh"
+fi
+
+# Load direnv stdlib if not already loaded
+if [ -z "$(declare -f -F watch_file)" ]; then
+  eval "$(asdf exec direnv stdlib)"
 fi
 
 ## Usage: use_asdf [...]
@@ -28,24 +34,27 @@ fi
 # Otherwise two argments are expected, a plugin name and version.
 # If no arguments are given, a .tool-versions file will be looked up.
 use_asdf() {
-  local plugin
-  local version
-  if [ -z "$*" ]; then
-    local tool_versions
-    tool_versions="$(find_up .tool-versions)"
-    if [ -f "$tool_versions" ]; then
-      use asdf "$tool_versions"
-    else
-      log_error "could not find .tool-versions file"
-      return 1
-    fi
+  if [ -z "$*" ] || [ "local" == "$*" ]; then
+    use_asdf "$(_local_versions_file)"
+
+  elif [ "current" == "$*" ]; then
+    eval "$(_load_current_plugins_env "$(_local_versions_file)")"
+
   elif [ -f "$1" ]; then
-    _load_plugins_env "$1"
-  elif [ -n "$1" ]; then
+    eval "$(_load_local_plugins_env "$1")"
+
+  elif [ -n "$1" ] && [ -z "$2" ]; then
     if ! (check_if_plugin_exists "$1"); then
       return 1
     fi
-    _load_plugin_env "$1" "$2"
+    eval "$(_load_plugin_version_and_file "$1")"
+
+  elif [ -n "$1" ] && [ -n "$2" ]; then
+    if ! (check_if_version_exists "$1" "$2"); then
+      return 1
+    fi
+    eval "$(_plugin_env_bash "$1" "$2")"
+
   else
     log_error "Invalid args for use asdf. Usage:"
     log_error "   use asdf TOOL_VERSIONS_FILE"
@@ -55,41 +64,84 @@ use_asdf() {
 }
 
 _xargs_par() {
-  xargs -n 1 -P "$(getconf _NPROCESSORS_ONLN)" "$@"
+  xargs -P "$(getconf _NPROCESSORS_ONLN)" "$@"
+}
+
+_pardo() {
+  local this_file="${BASH_SOURCE[0]}"
+  _xargs_par -n 1 "$this_file" 'do' "$@"
+}
+
+_local_versions_file() {
+  local tool_versions
+  tool_versions="$(find_up .tool-versions)"
+  if [ -f "$tool_versions" ]; then
+    echo "$tool_versions"
+  else
+    log_error "could not find .tool-versions file"
+    return 1
+  fi
 }
 
 _plugins_in_file() {
   local tool_versions=$1
-  cut -d'#' -f1 "$tool_versions" | cut -d' ' -f1 | awk NF
+  cut -d'#' -f1 "$tool_versions" | cut -d' ' -f1 | awk NF | uniq
 }
 
-_load_plugin_env() {
-  eval "$(_plugin_env_bash "$1" "$2")"
+_all_plugins_list() {
+  find "$(get_plugin_path)" -maxdepth 1 -mindepth 1 -exec basename '{}' \;
 }
 
-_load_plugins_env() {
+_load_current_plugins_env() {
+  _sort_all_plugins_list "$@" | _pardo _load_plugin_version_and_file
+}
+
+_sort_all_plugins_list() {
   local tool_versions=$1
-  local this_file="${BASH_SOURCE[0]}" #needs to before watch_file !
-  watch_file "$tool_versions"
-  eval "$(_plugins_in_file "$tool_versions" | _xargs_par "$this_file" 'do' _plugin_env_bash)"
+  local tmp_local_plugin_names
+  tmp_local_plugin_names="$(mktemp)"
+  _plugins_in_file "$tool_versions" | tee "$tmp_local_plugin_names"
+  _all_plugins_list | grep -v -F -f "$tmp_local_plugin_names"
+  rm "$tmp_local_plugin_names"
+}
+
+_load_local_plugins_env() {
+  local tool_versions=$1
+  _plugins_in_file "$tool_versions" | _pardo _load_plugin_version_and_file
 }
 
 _plugin_env() {
-  direnv dotenv bash <(env)
+  asdf exec direnv dotenv bash <(env)
+}
+
+# from asdf plugin_current_command
+_load_plugin_version_and_file() {
+  local plugin_name=$1
+  local versions_and_path
+  versions_and_path="$(find_versions "$plugin_name" "$(pwd)")"
+  if test -z "$versions_and_path"; then
+    return 0
+  fi
+
+  local path
+  path=$(cut -d '|' -f 2 <<<"$versions_and_path")
+  IFS=$'\n' read -r -a versions <<<"$(cut -d '|' -f 1 <<<"$versions_and_path" | uniq)"
+  for version in "${versions[@]}"; do
+    echo use_asdf "$plugin_name" "$version"
+  done
+  if [ -f "$path" ]; then
+    echo watch_file "$path"
+  fi
 }
 
 _plugin_env_bash() {
-  local plugin=$1
-  local version
+  local plugin="${1}"
+  local version="${2}"
   local old_path="$PATH"
-  version="${2:-$(get_preset_version_for "$plugin")}"
-  if [ -z "$version" ]; then
-    log_error "asdf: could not find current version for $plugin" >&2
-    return 1
+  if [ -n "$version" ]; then
+    echo "log_status using asdf $plugin $version"
+    with_plugin_env "$plugin" "$version" _plugin_env | sed "s#:$old_path#:'\"\$PATH\"'#"
   fi
-
-  echo "log_status using asdf $plugin $version"
-  with_plugin_env "$plugin" "$version" _plugin_env | sed "s#:$old_path#:'\"\$PATH\"'#"
 }
 
 if [ "do" == "$1" ]; then

--- a/shims/direnv_use_asdf
+++ b/shims/direnv_use_asdf
@@ -35,25 +35,25 @@ fi
 # Otherwise two argments are expected, a plugin name and version.
 # If no arguments are given, a .tool-versions file will be looked up.
 use_asdf() {
-  if [ -z "$*" ] || [ "local" == "$*" ]; then
-    use_asdf "$(_local_versions_file)"
+  if [ -z "$*" ] || [ "current" == "$*" ]; then
+    use_asdf global
+    use_asdf local
 
-  elif [ "current" == "$*" ]; then
-    eval "$(_load_current_plugins_env "$(_local_versions_file)")"
+  elif [ "global" == "$*" ]; then
+    eval "$(_load_global_plugins_env "$(_local_versions_file)")"
 
-  elif [ -f "$1" ]; then
+  elif [ "local" == "$*" ]; then
+    eval "$(_load_local_plugins_env "$(_local_versions_file)")"
+
+  elif [ -f "$1" ]; then # [tool-versions file]
     eval "$(_load_local_plugins_env "$1")"
 
-  elif [ -n "$1" ] && [ -z "$2" ]; then
-    if ! (check_if_plugin_exists "$1"); then
-      return 1
-    fi
+  elif [ -n "$1" ] && [ -z "$2" ]; then # [name] only
+    check_if_plugin_exists "$1"
     eval "$(_load_plugin_version_and_file "$1")"
 
-  elif [ -n "$1" ] && [ -n "$2" ]; then
-    if ! (check_if_version_exists "$1" "$2"); then
-      return 1
-    fi
+  elif [ -n "$1" ] && [ -n "$2" ]; then # [name] [version]
+    check_if_version_exists "$1" "$2"
     eval "$(_plugin_env_bash "$1" "$2")"
 
   else
@@ -64,13 +64,23 @@ use_asdf() {
   fi
 }
 
+_tail_r() {
+  # portable version of tail -r
+  cat -n | sort -nr | cut -f2
+}
+
 _xargs_par() {
-  xargs -P "$(getconf _NPROCESSORS_ONLN)" "$@"
+  local nproc="${ASDF_CONCURRENCY:-$(getconf _NPROCESSORS_ONLN || echo 1)}"
+  if [ "$nproc" -gt 1 ]; then
+    xargs -P "$nproc" "$@"
+  else
+    xargs "$@"
+  fi
 }
 
 _pardo() {
   local this_file="${BASH_SOURCE[0]}"
-  _xargs_par -n 1 "$this_file" 'do' "$@"
+  _xargs_par -L 1 "$this_file" 'do' "$@"
 }
 
 _local_versions_file() {
@@ -90,25 +100,26 @@ _plugins_in_file() {
 }
 
 _all_plugins_list() {
-  find "$(get_plugin_path)" -maxdepth 1 -mindepth 1 -exec basename '{}' \;
+  find "$(get_plugin_path)" -maxdepth 1 -mindepth 1 -exec basename '{}' \; | sort
 }
 
-_load_current_plugins_env() {
-  _sort_all_plugins_list "$@" | _pardo _load_plugin_version_and_file
-}
-
-_sort_all_plugins_list() {
+_except_local_plugins_list() {
   local tool_versions=$1
   local tmp_local_plugin_names
   tmp_local_plugin_names="$(mktemp)"
-  _plugins_in_file "$tool_versions" | tee "$tmp_local_plugin_names"
+  _plugins_in_file "$tool_versions" >"$tmp_local_plugin_names"
   _all_plugins_list | grep -v -F -f "$tmp_local_plugin_names"
   rm "$tmp_local_plugin_names"
 }
 
+_load_global_plugins_env() {
+  local tool_versions=$1
+  _except_local_plugins_list "$tool_versions" | _tail_r | _pardo _load_plugin_version_and_file
+}
+
 _load_local_plugins_env() {
   local tool_versions=$1
-  _plugins_in_file "$tool_versions" | _pardo _load_plugin_version_and_file
+  _plugins_in_file "$tool_versions" | _tail_r | _pardo _load_plugin_version_and_file
 }
 
 _plugin_env() {
@@ -128,10 +139,11 @@ _load_plugin_version_and_file() {
   path=$(cut -d '|' -f 2 <<<"$versions_and_path")
   IFS=$'\n' read -r -a versions <<<"$(cut -d '|' -f 1 <<<"$versions_and_path" | uniq)"
   for version in "${versions[@]}"; do
-    echo use_asdf "$plugin_name" "$version"
+    _plugin_env_bash "$plugin_name" "$version"
+    log_status "using asdf ${plugin_name} ${version}"
   done
   if [ -f "$path" ]; then
-    echo watch_file "$path"
+    asdf exec direnv watch bash "$path"
   fi
 }
 
@@ -140,7 +152,6 @@ _plugin_env_bash() {
   local version="${2}"
   local old_path="$PATH"
   if [ -n "$version" ]; then
-    echo "log_status using asdf $plugin $version"
     with_plugin_env "$plugin" "$version" _plugin_env | sed "s#:$old_path#:'\"\$PATH\"'#"
   fi
 }

--- a/shims/direnv_use_asdf
+++ b/shims/direnv_use_asdf
@@ -17,6 +17,7 @@
 
 # Load asdf util functions if not already loaded
 if [ -z "$(declare -f -F with_plugin_env)" ]; then
+  ASDF_DIR="${ASDF_DIR:-$(dirname "$(dirname "$(command -v asdf)")")}"
   # shellcheck disable=SC1090 # Can't follow non-constant source. Use a directive to specify location.
   source "$ASDF_DIR/lib/utils.sh"
 fi

--- a/shims/direnv_use_asdf
+++ b/shims/direnv_use_asdf
@@ -57,9 +57,7 @@ use_asdf() {
     eval "$(_plugin_env_bash "$1" "$2")"
 
   else
-    log_error "Invalid args for use asdf. Usage:"
-    log_error "   use asdf TOOL_VERSIONS_FILE"
-    log_error "   use asdf TOOL_NAME [VERSION]"
+    log_error "use asdf: Invalid args. See README.md for some examples."
     return 1
   fi
 }

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -1,0 +1,76 @@
+#!/usr/bin/env/bash
+
+die() {
+  echo "$@"
+  exit 1
+}
+
+ASDF_CMD="$(command -v asdf)"
+test -x "$ASDF_CMD" || die "Expected asdf command to be available."
+
+ASDF_DIRENV="$(dirname "$BATS_TEST_DIRNAME")"
+
+ASDF_WHERE_DIRENV="$(asdf where direnv)"
+test -n "$ASDF_WHERE_DIRENV" || die "Expected asdf-direnv to be already be installed."
+
+ASDF_DIRENV_VERSION="$(basename "$ASDF_WHERE_DIRENV")"
+PATH_WITHOUT_ASDF="$(echo "$PATH" | tr ':' $'\n' | grep -v asdf | tr $'\n' ':' | sed -e 's#:$##')"
+
+setup_asdf_direnv() {
+  BASE_DIR=$(mktemp -dt asdf.XXXX)
+  HOME=$BASE_DIR/home
+  ASDF_DIR=$HOME/.asdf
+  mkdir -p "$ASDF_DIR/plugins"
+  mkdir -p "$ASDF_DIR/installs"
+  mkdir -p "$ASDF_DIR/shims"
+  mkdir -p "$ASDF_DIR/tmp"
+
+  echo "direnv $ASDF_DIRENV_VERSION" > "$HOME/.tool-versions"
+
+  mkdir -p "$ASDF_DIR/installs/direnv"
+  ln -s "$ASDF_DIRENV" "$ASDF_DIR/plugins/direnv"
+  ln -s "$ASDF_WHERE_DIRENV" "$ASDF_DIR/installs/direnv/$ASDF_DIRENV_VERSION"
+
+  $ASDF_CMD reshim direnv "$ASDF_DIRENV_VERSION"
+
+  ASDF_BIN="$(dirname "$ASDF_CMD")"
+
+  PATH="$ASDF_BIN:$PATH_WITHOUT_ASDF" # NOTE: dont add shims directory to PATH
+
+  PROJECT_DIR=$HOME/project
+  mkdir -p "$PROJECT_DIR"
+  ENVRC="$PROJECT_DIR/.envrc"
+
+  eval "$(asdf exec direnv hook bash)"
+}
+
+clean_asdf_direnv() {
+  rm -rf "$BASE_DIR"
+  unset ASDF_DIR
+  unset ASDF_DATA_DIR
+}
+
+allow_direnv() {
+  asdf exec direnv allow "$ENVRC"
+}
+
+envrc_use_asdf() {
+  echo 'source $(asdf which direnv_use_asdf)' > "$ENVRC"
+  echo "use asdf $@" >> "$ENVRC"
+  allow_direnv
+}
+
+install_dummy_plugin() {
+  local plugin_name="$1"
+  local version="${2:-'1.0'}"
+
+  mkdir -p "$ASDF_DIR/plugins/${plugin_name}/shims/"
+  echo "echo $plugin_name" > "$ASDF_DIR/plugins/$plugin_name/shims/plugin_${plugin_name}"
+  chmod +x "$ASDF_DIR/plugins/$plugin_name/shims/plugin_${plugin_name}"
+
+  mkdir -p "$ASDF_DIR/installs/${plugin_name}/${version}/bin"
+  echo "echo $plugin_name $version" > "$ASDF_DIR/installs/${plugin_name}/${version}/bin/${plugin_name}"
+  chmod +x "$ASDF_DIR/installs/${plugin_name}/${version}/bin/${plugin_name}"
+
+  $ASDF_CMD reshim "$plugin_name" "$version"
+}

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -5,58 +5,57 @@ die() {
   exit 1
 }
 
-ASDF_CMD="$(command -v asdf)"
-test -x "$ASDF_CMD" || die "Expected asdf command to be available."
-
-ASDF_DIRENV="$(dirname "$BATS_TEST_DIRNAME")"
-
-ASDF_WHERE_DIRENV="$(asdf where direnv)"
-test -n "$ASDF_WHERE_DIRENV" || die "Expected asdf-direnv to be already be installed."
-
-ASDF_DIRENV_VERSION="$(basename "$ASDF_WHERE_DIRENV")"
-PATH_WITHOUT_ASDF="$(echo "$PATH" | tr ':' $'\n' | grep -v asdf | tr $'\n' ':' | sed -e 's#:$##')"
 
 setup_asdf_direnv() {
+  ASDF_CMD="$(command -v asdf)"
+  test -x "$ASDF_CMD" || die "Expected asdf command to be available."
+  ASDF_ROOT="$(dirname "$(dirname "$ASDF_CMD")")"
+
+  ASDF_DIRENV="$(dirname "$BATS_TEST_DIRNAME")"
+
+  ASDF_WHERE_DIRENV="$(asdf where direnv)"
+  test -n "$ASDF_WHERE_DIRENV" || die "Expected asdf-direnv to be already be installed."
+
+  ASDF_DIRENV_VERSION="$(basename "$ASDF_WHERE_DIRENV")"
+  PATH_WITHOUT_ASDF="$(echo "$PATH" | tr ':' $'\n' | grep -v asdf | tr $'\n' ':' | sed -e 's#:$##')"
+
   BASE_DIR=$(mktemp -dt asdf.XXXX)
   HOME=$BASE_DIR/home
-  ASDF_DIR=$HOME/.asdf
-  mkdir -p "$ASDF_DIR/plugins"
-  mkdir -p "$ASDF_DIR/installs"
-  mkdir -p "$ASDF_DIR/shims"
-  mkdir -p "$ASDF_DIR/tmp"
+  ASDF_DIR="$HOME/.asdf"
+  ASDF_DATA_DIR="$ASDF_DIR"
+  PATH="${ASDF_DIR}/bin:$PATH_WITHOUT_ASDF" # NOTE: dont add shims directory to PATH
+
+  mkdir -p "${ASDF_DIR}"/{bin,lib}
+  mkdir -p "${ASDF_DATA_DIR}"/{plugins,installs,shims}
+  cp "$ASDF_ROOT"/bin/asdf "${ASDF_DIR}/bin"
+  cp -r "$ASDF_ROOT"/lib/* "${ASDF_DIR}/lib"
+
+  ln -s "$ASDF_DIRENV" "${ASDF_DATA_DIR}/plugins/direnv"
+  mkdir -p "${ASDF_DATA_DIR}/installs/direnv"
+  ln -s "$ASDF_WHERE_DIRENV" "${ASDF_DATA_DIR}/installs/direnv/$ASDF_DIRENV_VERSION"
 
   echo "direnv $ASDF_DIRENV_VERSION" > "$HOME/.tool-versions"
-
-  mkdir -p "$ASDF_DIR/installs/direnv"
-  ln -s "$ASDF_DIRENV" "$ASDF_DIR/plugins/direnv"
-  ln -s "$ASDF_WHERE_DIRENV" "$ASDF_DIR/installs/direnv/$ASDF_DIRENV_VERSION"
-
-  $ASDF_CMD reshim direnv "$ASDF_DIRENV_VERSION"
-
-  ASDF_BIN="$(dirname "$ASDF_CMD")"
-
-  PATH="$ASDF_BIN:$PATH_WITHOUT_ASDF" # NOTE: dont add shims directory to PATH
+  asdf reshim direnv "$ASDF_DIRENV_VERSION"
 
   PROJECT_DIR=$HOME/project
   mkdir -p "$PROJECT_DIR"
-  ENVRC="$PROJECT_DIR/.envrc"
-
-  eval "$(asdf exec direnv hook bash)"
 }
 
 clean_asdf_direnv() {
   rm -rf "$BASE_DIR"
-  unset ASDF_DIR
-  unset ASDF_DATA_DIR
+}
+
+envrc_load() {
+  eval "$(asdf exec direnv export bash)"
 }
 
 allow_direnv() {
-  asdf exec direnv allow "$ENVRC"
+  asdf exec direnv allow
 }
 
 envrc_use_asdf() {
-  echo 'source $(asdf which direnv_use_asdf)' > "$ENVRC"
-  echo "use asdf $@" >> "$ENVRC"
+  echo 'source $(asdf which direnv_use_asdf)' > ".envrc"
+  echo "use asdf $*" >> ".envrc"
   allow_direnv
 }
 
@@ -64,13 +63,13 @@ install_dummy_plugin() {
   local plugin_name="$1"
   local version="${2:-'1.0'}"
 
-  mkdir -p "$ASDF_DIR/plugins/${plugin_name}/shims/"
-  echo "echo $plugin_name" > "$ASDF_DIR/plugins/$plugin_name/shims/plugin_${plugin_name}"
-  chmod +x "$ASDF_DIR/plugins/$plugin_name/shims/plugin_${plugin_name}"
+  mkdir -p "${ASDF_DATA_DIR}/plugins/${plugin_name}/shims/"
+  echo "echo Plugin $plugin_name" > "${ASDF_DATA_DIR}/plugins/$plugin_name/shims/plugin_${plugin_name}"
+  chmod +x "${ASDF_DATA_DIR}/plugins/$plugin_name/shims/plugin_${plugin_name}"
 
-  mkdir -p "$ASDF_DIR/installs/${plugin_name}/${version}/bin"
-  echo "echo $plugin_name $version" > "$ASDF_DIR/installs/${plugin_name}/${version}/bin/${plugin_name}"
-  chmod +x "$ASDF_DIR/installs/${plugin_name}/${version}/bin/${plugin_name}"
+  mkdir -p "${ASDF_DATA_DIR}/installs/${plugin_name}/${version}/bin"
+  echo "echo This is $plugin_name $version" > "${ASDF_DATA_DIR}/installs/${plugin_name}/${version}/bin/${plugin_name}"
+  chmod +x "${ASDF_DATA_DIR}/installs/${plugin_name}/${version}/bin/${plugin_name}"
 
-  $ASDF_CMD reshim "$plugin_name" "$version"
+  asdf reshim "$plugin_name" "$version"
 }

--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -48,14 +48,234 @@ teardown() {
   [ "$FOO" ==  "BAR" ]
 }
 
-@test "use asdf dummy 1.0 needs no local tool-versions file" {
-  cd "$PROJECT_DIR"
-
+@test "use asdf [name] [version] - prepends plugin/bin to PATH" {
   install_dummy_plugin dummy 1.0
+
+  cd "$PROJECT_DIR"
   envrc_use_asdf dummy 1.0
 
   [ ! $(command -v dummy) ] # not available
   envrc_load
+
+  run dummy
+  [ "$output" == "This is dummy 1.0" ] # executable in path
+
+  # plugin bin at head of PATH
+  path_as_lines | sed -n 1p | grep "$(dummy_bin_path dummy 1.0)"
+}
+
+
+@test "use asdf [name] [version] - prepends plugin custom shims to PATH" {
+  echo "If a plugin has helper shims defined, they also appear on PATH"
+  install_dummy_plugin dummy 1.0 mummy
+
+  cd "$PROJECT_DIR"
+  envrc_use_asdf dummy 1.0
+
+  [ ! $(command -v mummy) ] # not available
+  [ ! $(command -v dummy) ] # not available
+  envrc_load
+
+  run mummy
+  [ "$output" == "This is dummy mummy shim" ] # executable in path
+
+  run dummy
+  [ "$output" == "This is dummy 1.0" ] # executable in path
+
+  # plugin bin at head of PATH
+  path_as_lines | sed -n 1p | grep "$(dummy_shims_path dummy 1.0)"
+  path_as_lines | sed -n 2p | grep "$(dummy_bin_path dummy 1.0)"
+}
+
+@test "use asdf [name] [version] - exports plugin custom env not only PATH" {
+  install_dummy_plugin dummy 1.0
+  cat <<-EOF > "$ASDF_DATA_DIR/plugins/dummy/bin/exec-env"
+#!/usr/bin/env bash
+export JOJO=JAJA
+EOF
+  chmod +x "$ASDF_DATA_DIR/plugins/dummy/bin/exec-env"
+
+  cd "$PROJECT_DIR"
+  envrc_use_asdf dummy 1.0
+  envrc_load
+
+  [ "$JOJO" == "JAJA" ] # Env exported by plugin
+}
+
+@test "use asdf [name] - determines version from tool-versions" {
+  install_dummy_plugin dummy 1.0
+  install_dummy_plugin dummy 2.0
+
+  cd "$PROJECT_DIR"
+  asdf global dummy 1.0
+  asdf local dummy 2.0
+  envrc_use_asdf dummy
+  envrc_load
+
+  run dummy
+  [ "$output" == "This is dummy 2.0" ] # executable in path
+}
+
+
+@test "use asdf [name] - watches tool-versions for changes" {
+  install_dummy_plugin dummy 1.0
+
+  cd "$PROJECT_DIR"
+  asdf local dummy 1.0
+  envrc_use_asdf dummy
+  envrc_load
+
+  asdf exec direnv status | grep -F 'Loaded watch: ".tool-versions"'
+}
+
+@test "use asdf [name] - watches plugin legacy file for changes" {
+  install_dummy_plugin dummy 1.0
+  setup_dummy_legacyfile dummy .dummy-version
+
+  cd "$PROJECT_DIR"
+  echo "1.0" > "$PROJECT_DIR/.dummy-version"
+  envrc_use_asdf dummy
+  envrc_load
+
   run dummy
   [ "$output" == "This is dummy 1.0" ]
+
+  asdf exec direnv status | grep -F 'Loaded watch: ".dummy-version"'
+}
+
+@test "use asdf local - loads only from local tool-versions" {
+  install_dummy_plugin dummy 1.0
+  install_dummy_plugin dummy 2.0
+  install_dummy_plugin gummy 1.0
+
+  cd "$PROJECT_DIR"
+  asdf global dummy 1.0
+  asdf global gummy 1.0
+  asdf local  dummy 2.0
+
+  envrc_use_asdf local
+  envrc_load
+
+  run dummy
+  [ "$output" == "This is dummy 2.0" ]
+
+  [ ! $(command -v gummy) ] # gummy not available
+  [ ! $(path_as_lines | grep "$(dummy_bin_path dummy 1.0)") ]
+}
+
+@test "use asdf local - watches tool-versions for changes" {
+  install_dummy_plugin dummy 1.0
+
+  cd "$PROJECT_DIR"
+  asdf local dummy 1.0
+  envrc_use_asdf local
+  envrc_load
+
+  asdf exec direnv status | grep -F 'Loaded watch: ".tool-versions"'
+}
+
+@test "use asdf current - activates currently selected plugins" {
+  install_dummy_plugin dummy 1.0
+  install_dummy_plugin dummy 2.0
+  install_dummy_plugin gummy 1.0
+  install_dummy_plugin puppy 2.0
+  install_dummy_plugin mummy 1.0 # installed, but not seelcted globally nor locally
+
+  setup_dummy_legacyfile dummy .dummy-version
+
+  cd "$PROJECT_DIR"
+  asdf global dummy 1.0
+  asdf global gummy 1.0
+
+  echo "2.0" > "$PROJECT_DIR/.dummy-version"
+  asdf local puppy 2.0
+
+  envrc_use_asdf current
+  envrc_load
+
+  run dummy # selected from legacyfile
+  [ "$output" == "This is dummy 2.0" ]
+
+  run puppy # selected from local tool-versions
+  [ "$output" == "This is puppy 2.0" ]
+
+  run gummy # selected from global tool-versions
+  [ "$output" == "This is gummy 1.0" ]
+
+  [ ! $(command -v mummy) ] # never selected
+  [ ! $(path_as_lines | grep "$(dummy_bin_path dummy 1.0)") ]
+}
+
+@test "use asdf current - watches selection files" {
+  install_dummy_plugin dummy 1.0
+  install_dummy_plugin dummy 2.0
+  install_dummy_plugin gummy 1.0
+  install_dummy_plugin puppy 2.0
+  install_dummy_plugin mummy 1.0 # installed, but not seelcted globally nor locally
+
+  cd "$PROJECT_DIR"
+  asdf global dummy 1.0
+  asdf global gummy 1.0
+
+  asdf local dummy 2.0
+  asdf local puppy 2.0
+
+  envrc_use_asdf current
+  envrc_load
+
+  asdf exec direnv status | grep -F 'Loaded watch: ".tool-versions"'
+  asdf exec direnv status | grep -F 'Loaded watch: "../.tool-versions"'
+}
+
+@test "use asdf current - watches legacy files" {
+  install_dummy_plugin dummy 2.0
+  setup_dummy_legacyfile dummy .dummy-version
+
+  cd "$PROJECT_DIR"
+  echo "2.0" > "$PROJECT_DIR/.dummy-version"
+
+  envrc_use_asdf current
+  envrc_load
+
+  asdf exec direnv status
+  asdf exec direnv status | grep -F 'Loaded watch: ".dummy-version"'
+}
+
+@test "use asdf current - sets local tools on PATH before global tools" {
+  # NOTE: order between tools is undefined when xargs maxproc > 1
+  export ASDF_CONCURRENCY=1 # Disabled xargs parallelism for deterministic tests
+
+  install_dummy_plugin dummy 1.0
+  install_dummy_plugin gummy 1.0
+  install_dummy_plugin mummy 1.0
+  install_dummy_plugin puppy 1.0
+  install_dummy_plugin rummy 1.0
+
+  setup_dummy_legacyfile dummy .dummy-version
+
+  cd "$PROJECT_DIR"
+  asdf global mummy 1.0
+  asdf global rummy 1.0
+
+  echo "1.0" > "$PROJECT_DIR/.dummy-version"
+  asdf local puppy 1.0
+  asdf local gummy 1.0
+
+  envrc_use_asdf current
+  envrc_load
+
+  path_as_lines
+  local dummy_line="$(path_as_lines | grep -n -F "$(dummy_bin_path dummy 1.0)" | cut -d: -f1)"
+  local gummy_line="$(path_as_lines | grep -n -F "$(dummy_bin_path gummy 1.0)" | cut -d: -f1)"
+  local mummy_line="$(path_as_lines | grep -n -F "$(dummy_bin_path mummy 1.0)" | cut -d: -f1)"
+  local puppy_line="$(path_as_lines | grep -n -F "$(dummy_bin_path puppy 1.0)" | cut -d: -f1)"
+  local rummy_line="$(path_as_lines | grep -n -F "$(dummy_bin_path rummy 1.0)" | cut -d: -f1)"
+
+  [ "$puppy_line" -lt "$gummy_line" ] # first tool in tool-versions is also first on PATH
+  [ "$gummy_line" -lt "$mummy_line" ] # local plugins should be on PATH before gloabl ones
+  [ "$puppy_line" -lt "$mummy_line" ]
+  [ "$puppy_line" -lt "$dummy_line" ] # since dummy is not in tool-versions its loaded after local tools
+  # global plugins order is lexicographical since they are not in tool-versions file
+  [ "$dummy_line" -lt "$mummy_line" ] # dummy is resolved by `use asdf global` since its not in tool-versions
+  [ "$mummy_line" -lt "$rummy_line" ]
 }

--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# -*- shell-script -*-
+
+load test_helpers
+
+setup() {
+  setup_asdf_direnv
+}
+
+teardown() {
+  clean_asdf_direnv
+}
+
+@test "asdf executable should be on path" {
+  command -v asdf
+}
+
+@test "direnv executable should not be on path" {
+  [ ! $(command -v direnv) ]
+}
+
+@test "direnv_use_asdf should not be on path" {
+  [ ! $(command -v direnv_use_asdf) ]
+}
+
+@test "direnv is available via asdf" {
+  asdf exec direnv --version
+}
+
+@test "direnv_use_asdf is available via asdf" {
+  asdf which direnv_use_asdf
+}
+
+@test "dummy 1.0 is available via asdf exec" {
+  install_dummy_plugin "dummy" "1.0"
+  ASDF_DUMMY_VERSION=1.0 asdf exec dummy
+  [ "$output" = "dummy 1.0" ]
+}
+
+@test "use asdf dummy 1.0 explicitly activates" {
+  install_dummy_plugin "dummy" "1.0"
+  echo "dummy 1.0" > "$PROJECT_DIR/.tool-versions"
+  envrc_use_asdf # no args should load local file
+
+  [ ! $(command -v dummy) ] # not available before cd
+  cd "$PROJECT_DIR"
+  echo $PATH
+  tree -a $HOME
+  command -v dummy # available after cd
+}


### PR DESCRIPTION
In your `.envrc` file now you can do: `use asdf current`.
And it will load the same plugins and versions as listed by
the output of `asdf current`.

Notice that `use asdf current` is a bit slow since it will
try to determine the version for each installed plugin
(same thing that `asdf current` does). But, the upside is
that you will have not only local plugins active but also
those in global ~/.tool-versions file (as resolved by asdf).

This means `use asdf current` will also activate plugins
that use legacy files and thus are not present inside
`.tool-versions`. (this was a limitation of `use asdf local`)

The old behaviour is now named `use asdf local` and is
currently still the default if you give no args to `use asdf`.
This is because `use asdf current` is slower, and I'm not
sure all people would like that by default.

TODO:

- [x] Add lots of BATS test.
- [x] Decide if `use asdf current` becomes default.
- [x] Improve docs.

Alternative implementation for #12.
Fixes #13