### PR TITLE
Fixes search PATH to make more sense

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Then edit your `.bashrc` or equivalent shell profile:
 
 # In order to bypass asdf shims. We *only* add the `ASDF_DIR/bin`
 # directory to PATH, since we still want to use `asdf` but not its shims.
-export PATH="$PATH:$HOME/.asdf/bin"
+export PATH="$HOME/.asdf/bin:$PATH"
 
 # Hook direnv into your shell.
 eval "$(asdf exec direnv hook bash)"


### PR DESCRIPTION
The current instructions place `asdf` as last in PATH and requires one to run `asdf exec` for anything which is increasingly furstrating