### PR TITLE
Ensure multiple versions when loading plugin

### DIFF
--- a/bin/direnv_use_asdf
+++ b/bin/direnv_use_asdf
@@ -162,7 +162,13 @@ _load_plugin_version_and_file() {
 
   local path
   path=$(cut -d '|' -f 2 <<<"$versions_and_path")
-  IFS=$'\n' read -r -a versions <<<"$(cut -d '|' -f 1 <<<"$versions_and_path" | uniq)"
+  local versions=()
+  while IFS=$' \t' read -r -a inline_versions; do
+    for ((idx = ${#inline_versions[@]} - 1; idx >= 0; idx--)); do
+      versions+=("${inline_versions[idx]}")
+    done
+  done <<<"$(cut -d '|' -f 1 <<<"$versions_and_path" | uniq | _tail_r)"
+
   for version in "${versions[@]}"; do
     echo log_status "using asdf ${plugin_name} ${version}"
     _plugin_env_bash "$plugin_name" "$version"

--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -48,6 +48,33 @@ teardown() {
   [ "$FOO" ==  "BAR" ]
 }
 
+@test "use multiple versions for same plugin - multiline" {
+  install_dummy_plugin dummy 1.0
+  install_dummy_plugin dummy 2.0
+
+  cd "$PROJECT_DIR"
+  echo -e "\ndummy 2.0" >> .tool-versions
+  echo -e "\ndummy 1.0" >> .tool-versions
+  envrc_use_asdf dummy
+  envrc_load
+
+  path_as_lines | sed -n 1p | grep "$(dummy_bin_path dummy 2.0)"
+  path_as_lines | sed -n 2p | grep "$(dummy_bin_path dummy 1.0)"
+}
+
+@test "use multiple versions for same plugin - inline" {
+  install_dummy_plugin dummy 1.0
+  install_dummy_plugin dummy 2.0
+
+  cd "$PROJECT_DIR"
+  asdf global dummy 2.0 1.0
+  envrc_use_asdf dummy
+  envrc_load
+
+  path_as_lines | sed -n 1p | grep "$(dummy_bin_path dummy 2.0)"
+  path_as_lines | sed -n 2p | grep "$(dummy_bin_path dummy 1.0)"
+}
+
 @test "use asdf [name] [version] - prepends plugin/bin to PATH" {
   install_dummy_plugin dummy 1.0
 


### PR DESCRIPTION
I'm not sure if this is intended or not, current implementation ignores multiple versions with same plugin. For example:
```
direnv 2.21.2
python 3.8.2
python 2.7.17 # ignored

# Actual paths
/root/.asdf/plugins/direnv/shims
/root/.asdf/installs/direnv/2.21.2/bin
/root/.asdf/installs/python/3.8.2/bin
/root/.asdf/bin
```
```
direnv 2.21.2
python 3.8.2 2.7.17 # both versions are ignored

# Actual paths
/root/.asdf/plugins/direnv/shims
/root/.asdf/installs/direnv/2.21.2/bin
/root/.asdf/installs/python/3.8.2
/root/.asdf/installs/direnv/2.21.2/env/2.7.17/bin
/root/.asdf/bin
```

I think changing `_load_plugin_version_and_file` to ensure multiple versions for same plugin can fixes #44 🙂