### PR TITLE
Update asdf script extension .sh -> .bash

### DIFF
--- a/bin/direnv_use_asdf
+++ b/bin/direnv_use_asdf
@@ -27,7 +27,11 @@ _load_asdf_utils() {
   if [ -z "$(declare -f -F with_plugin_env)" ]; then
     ASDF_DIR="${ASDF_DIR:-"$(command -v asdf | xargs dirname | xargs dirname)"}"
     # shellcheck disable=SC1090 # Can't follow non-constant source. Use a directive to specify location.
-    source "$ASDF_DIR/lib/utils.sh"
+    if [ -f "$ASDF_DIR/lib/utils.sh" ]; then
+      source "$ASDF_DIR/lib/utils.sh"
+    else
+      source "$ASDF_DIR/lib/utils.bash"
+    fi
   fi
 }
 


### PR DESCRIPTION
asdf renamed bash scripts to .bash, causing an error with `use asdf`