### PR TITLE
Check for successful env file generation before trying to source_env

### DIFF
--- a/shims/direnv_use_asdf
+++ b/shims/direnv_use_asdf
@@ -23,5 +23,9 @@
 # Otherwise two argments are expected, a plugin name and version.
 # If no arguments are given, a .tool-versions file will be looked up.
 use_asdf() {
-  source_env "$("$(asdf which direnv_use_asdf | xargs dirname | xargs dirname)/bin/direnv_use_asdf" _asdf_env_file "$@")"
+  local env
+  env=$("$(asdf which direnv_use_asdf | xargs dirname | xargs dirname)/bin/direnv_use_asdf" _asdf_env_file "$@")
+  if [ -n "$env" ]; then
+    source_env "$env"
+  fi
 }


### PR DESCRIPTION
The `direnv_use_asdf` shim currently tries to source the result of `direnv_use_asdf _asdf_env_file` without checking whether it actually generated a file. However, that script exits early if it finds a problem (such as when a requested tool version isn't installed), so it might not generate an env file and its output might be empty. In that case the shim will try to `source_env ""`, causing direnv to produce a confusing message "referenced  does not exist". This patch just checks whether the `_asdf_env_file`  command generated a file before trying to source it.

The current behaviour:

```
$ echo use asdf elixir 1.10.0 > .envrc
direnv: error /home/evhan/code/asdf-direnv/.envrc is blocked. Run `direnv allow` to approve its content
$ direnv allow
direnv: loading ~/code/asdf-direnv/.envrc
direnv: using asdf elixir 1.10.0
direnv: Creating env file /home/evhan/.asdf/installs/direnv/2.21.2/env/1979352468-3847824683-159080489-3401769500
version 1.10.0 is not installed for elixir
direnv: referenced  does not exist
```

With this patch:

```
$ touch .envrc
direnv: loading ~/code/asdf-direnv/.envrc
direnv: using asdf elixir 1.10.0
direnv: Creating env file /home/evhan/.asdf/installs/direnv/2.21.2/env/1979352468-3847824683-705602507-3401769500
version 1.10.0 is not installed for elixir
```