### PR TITLE
modify list-all versions regex

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -14,6 +14,6 @@ sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval "$cmd $releases_path" | grep 'tag_name' | sed -e 's/^.* "//;s/^v//;s/",$//' | sort_versions | xargs)
+versions=$(eval "$cmd $releases_path" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v*//;s/\",//' | sort_versions | xargs)
 
 echo "$versions"

--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -290,12 +290,3 @@ EOF
   [ "$dummy_line" -lt "$mummy_line" ] # dummy is resolved by `use asdf global` since its not in tool-versions
   [ "$mummy_line" -lt "$rummy_line" ]
 }
-
-@test "use asdf list-all - list available release versions" {
-  cd "$PROJECT_DIR"
-
-  echo $(asdf list-all direnv)
-  latest_version=$(asdf list-all direnv | tail -1)
-
-  [ "$latest_version" == "was" ]
-}

--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -290,3 +290,12 @@ EOF
   [ "$dummy_line" -lt "$mummy_line" ] # dummy is resolved by `use asdf global` since its not in tool-versions
   [ "$mummy_line" -lt "$rummy_line" ]
 }
+
+@test "use asdf list-all - list available release versions" {
+  cd "$PROJECT_DIR"
+
+  echo $(asdf list-all direnv)
+  latest_version=$(asdf list-all direnv | tail -1)
+
+  [ "$latest_version" == "was" ]
+}


### PR DESCRIPTION
before this change calling list-all returned the string 'was'

after this change calling list-all will return a list of release versions