### PR TITLE
Bump version shown in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ most recent direnv version:
 
 ```bash
 asdf plugin-add direnv
-asdf install direnv 2.20.0
-asdf global  direnv 2.20.0
+asdf install direnv 2.28.0
+asdf global  direnv 2.28.0
 ```
 
 Then edit your `.bashrc` or equivalent shell profile:

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ most recent direnv version:
 
 ```bash
 asdf plugin-add direnv
-asdf install direnv 2.28.0
-asdf global  direnv 2.28.0
+asdf install direnv latest
+asdf global direnv latest
 ```
 
 Then edit your `.bashrc` or equivalent shell profile:


### PR DESCRIPTION
This would be ideal, so that nobody has to update the `README` again the next release:
```bash
asdf install direnv latest
asdf global  direnv latest
```

However, this line seems to not work:
```bash
asdf global  direnv latest
```

