### PR TITLE
More robust error handling

### DIFF
--- a/lib/commands/command-hook-asdf.bash
+++ b/lib/commands/command-hook-asdf.bash
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
 use_asdf() {
-  source_env "$(asdf direnv _asdf_cached_envrc "$@")"
+  if ! env_file="$(asdf direnv _asdf_cached_envrc "$@")"; then
+    log_error "Error generating asdf cached envrc"
+    exit 1
+  else
+    source_env "$env_file"
+  fi
 }
 
 if [ "1" == "$DIRENV_IN_ENVRC" ] && [ "$0" == "${BASH_SOURCE[0]}" ]; then


### PR DESCRIPTION
More robust error handling

I really like this plugin, but I think the error messages and behavior
when you don't have the right plugins installed (or the wrong versions
of those binaries provided by plugins) could be improved. That's what
I've done here:

- Prevent creating the cached env file if there are any errors.
- Raise an error if we depend on a plugin that isn't installed. (This
  fixes https://github.com/asdf-community/asdf-direnv/issues/49)
- Raise an error if we depend on a version of a tool that isn't
  installed.

Before
======

Setup:

    $ cat .tool-versions
    maven 3.8.4
    $ cat .envrc
    use asdf

Try loading direnv, note that we're missing the `maven` plugin:

    $ direnv reload
    direnv: loading ~/tmp/bugging/.envrc
    direnv: using asdf
    direnv: Creating env file /home/jeremy/.asdf/installs/direnv/2.30.3/env/1560215600-3608870685-3896840882-2383759277
    No such plugin: maven
    direnv: loading ~/.asdf/installs/direnv/2.30.3/env/1560215600-3608870685-3896840882-2383759277
    direnv: using asdf direnv 2.30.3
    direnv: using asdf maven 3.8.4
    direnv: export ~PATH

If you look carefully, you'll see a "No such plugin: maven" in there, but we
went on to do other things. For example, note how that env cache file got
created, which means even if we add the maven plugin, we're going to have to do
something to bust the cache to fix this:

    $ cat /home/jeremy/.asdf/installs/direnv/2.30.3/env/1560215600-3608870685-3896840882-2383759277
    log_status using asdf direnv 2.30.3
    PATH_add /home/jeremy/.asdf/installs/direnv/2.30.3/bin
    watch_file /home/jeremy/.tool-versions
    log_status using asdf maven 3.8.4
    PATH_add
    watch_file /home/jeremy/tmp/bugging/.tool-versions

Install the maven plugin. Now how we reuse that env cache file:

    $ asdf plugin add maven
    $ cd ..; cd -
    direnv: unloading
    ~/tmp/bugging
    direnv: loading ~/tmp/bugging/.envrc
    direnv: using asdf
    direnv: loading ~/.asdf/installs/direnv/2.30.3/env/1560215600-3608870685-3896840882-2383759277
    direnv: using asdf direnv 2.30.3
    direnv: using asdf maven 3.8.4
    direnv: export ~PATH

Now blow the cache:

    $ touch .envrc
    direnv: loading ~/tmp/bugging/.envrc
    direnv: using asdf
    direnv: Creating env file /home/jeremy/.asdf/installs/direnv/2.30.3/env/1560215600-3608870685-472850511-2383759277
    direnv: loading ~/.asdf/installs/direnv/2.30.3/env/1560215600-3608870685-472850511-2383759277
    direnv: using asdf direnv 2.30.3
    direnv: using asdf maven 3.8.4
    direnv: export ~PATH

Ok, no errors. But I know I don't have maven 3.8.4 installed. What's going to happen here?

    $ which mvn
    mvn not found
    $ mvn --version
    zsh: command not found: mvn
    $ echo $PATH
    /home/jeremy/.asdf/installs/maven/3.8.4/bin:...
    $ ls -alh /home/jeremy/.asdf/installs/maven/3.8.4/bin
    ls: cannot access '/home/jeremy/.asdf/installs/maven/3.8.4/bin': No such file or directory

Ooh so you can see that even when maven 3.8.4 isn't installed, we end up with a
nonexistent folder on the `PATH` identifying where that plugin will eventually
be installed.

Install the correct version of maven:

    $ asdf install maven 3.8.4

And we immediately start finding `mvn`:

    $ which mvn
    /home/jeremy/.asdf/installs/maven/3.8.4/bin/mvn

After
=====

Setup:

    $ cat .tool-versions
    maven 3.8.4
    $ cat .envrc
    use asdf

Try loading direnv, note that we're missing the `maven` plugin:

    $ direnv reload
    direnv: loading ...
    direnv: using asdf
    direnv: Creating env file ...
    direnv: asdf plugin not installed: maven
    direnv: Error generating asdf cached envrc

Add the plugin and try again (note: we don't have the right version of
`maven` installed yet):

    $ asdf plugin add maven
    $ cd ..; cd -
    direnv: loading ~/tmp/bugging/.envrc
    direnv: using asdf
    direnv: Creating env file ...
    direnv: maven 3.8.4 not installed. Run 'asdf install' and try again.
    direnv: Error generating asdf cached envrc

Install the missing version and try again:

    $ asdf install
    ...
    $ cd ..; cd -
    direnv: loading ~/tmp/bugging/.envrc
    direnv: using asdf
    direnv: Creating env file ...
    direnv: loading ~/.asdf/installs/direnv/2.30.3/env/1560215600-3608870685-1742556474-2383759277
    direnv: using asdf direnv 2.30.3
    direnv: using asdf maven 3.8.4
    direnv: export ~PATH
    $ which mvn
    /home/jeremy/.asdf/installs/maven/3.8.4/bin/mvn

