### PR TITLE
Don't bother checking if a "system" version of a plugin is installed.

### DIFF
--- a/lib/commands/command.bash
+++ b/lib/commands/command.bash
@@ -176,10 +176,12 @@ _plugin_env_bash() {
     log_error "asdf plugin not installed: $plugin"
     exit 1
   fi
-  install_path=$(get_install_path "$plugin" "version" "$version")
-  if [ ! -d "$install_path" ]; then
-    log_error "$plugin $version not installed. Run 'asdf install' and try again."
-    exit 1
+  if [ "$version" != "system" ]; then
+    install_path=$(get_install_path "$plugin" "version" "$version")
+    if [ ! -d "$install_path" ]; then
+      log_error "$plugin $version not installed. Run 'asdf install' and try again."
+      exit 1
+    fi
   fi
   old_env="$(_direnv_bash_dump)"
   new_env="$(with_plugin_env "$plugin" "$version" _direnv_bash_dump | _new_items <(echo -n "$old_env"))"


### PR DESCRIPTION
This fixes https://github.com/asdf-community/asdf-direnv/issues/90.

This doesn't feel like the most elegant solution: it feels a little
strange that we can't detect situations where the user asks for say a
system python. However, after digging through asdf source code, I don't
think asdf *itself* really has any concept of "is this system version of
this thing installed" or not. Here's the relevant code:
https://github.com/asdf-vm/asdf/blob/9ee24a3a75e28ca0757d0b99fa00ce49466777a8/lib/utils.bash#L548-L552.
This doesn't really check if the system version exists, it just says
"ok, we'll run with an unmodified environment".