### PR TITLE
Alternative way of loading asdf utils

### DIFF
--- a/lib/commands/command.bash
+++ b/lib/commands/command.bash
@@ -10,15 +10,9 @@ fi
 
 _load_asdf_utils() {
   if [ -z "$(declare -f -F with_plugin_env)" ]; then
-    ASDF_DIR="${ASDF_DIR:-"$(command -v asdf | xargs dirname | xargs dirname)"}"
-    # shellcheck disable=SC1090 # Can't follow non-constant source. Use a directive to specify location.
-    if [ -f "$ASDF_DIR/lib/utils.sh" ]; then
-      # shellcheck disable=SC1091
-      source "$ASDF_DIR/lib/utils.sh"
-    else
-      # shellcheck disable=SC1091
-      source "$ASDF_DIR/lib/utils.bash"
-    fi
+    ASDF_DIR="$(asdf info 2>/dev/null | grep ASDF_DIR | cut -d= -f2-)"
+    # shellcheck source=/dev/null # we don't want shellcheck trying to find this file
+    source "$ASDF_DIR/lib/utils.bash"
   fi
 }
 


### PR DESCRIPTION
This fixes #95

This also drops support for older versions of `asdf` that have a
`utils.sh` file instead of a `utils.bash` file. That change happened way
back in asdf 0.7.7 in March 2020:
asdf-vm/asdf@52cbf11,
so I think it's safe to drop support by now.