### PR TITLE
Use EditorConfig for shfmt "parser or printer flags"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+switch_case_indent = true
 
 [Makefile]
 indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SH_SRCFILES = $(shell git ls-files "bin/*" "*.bash")
-SHFMT_BASE_FLAGS = -s -i 2 -ci
+SHFMT_BASE_FLAGS = -s
 
 fmt:
 	shfmt -w $(SHFMT_BASE_FLAGS) $(SH_SRCFILES)


### PR DESCRIPTION
I spent some time this weekend getting my neovim configuration polished
up for working on shell scripts.

Once I got my editor auto-running `shfmt` for me, I found some
differences started to arise (for example, it was de-indenting all our
switch statements). Turns out we invoke `shfmt` with some non-default
settings (such as `-ci`), and my editor didn't know about that. I poked
around a little bit hoping to find some custom `.shfmtrc` file or
something we could put in the root of our repo. Turns out shfmt actually
knows about `.editorconfig` files, which we already have in this repo!

From
https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#description:

> If any EditorConfig files are found, they will be used to apply
> formatting options. If any parser or printer flags are given to the
> tool, no EditorConfig files will be used.

We were passing `-i 2` and `-ci`, which are both "printer flags", shfmt
was ignoring our `.editorconfig` file.

The fix is as simple as removing these two flags and updating our
`.editorconfig` file to have corresponding rules:

- We already had `indent_size = 2` in our `.editorconfig`. Bonus: we
  don't have to specify our indent size in 2 places anymore!
- I added `switch_case_indent = true` to our `.editorconfig` file. I
  guess this is a shfmt specific extension to editorconfig? It's
  documented here:
  https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#examples,
  but I don't see any mention of it here:
  https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
  At first, I scoped this specifically to `.bash` files, but then I
  realized we've written shell code in files with other extensions (such as
  `bin/install` and `test/use_asdf.bats`). So, I've left this rule
  applicable to all files. It doesn't seem to cause any weirdness when I
  edit a file where it makes no sense (such as our `Makefile`).

Unfortunately, it doesn't look like there's a way of specifying `-s` via
the `.editorconfig` file, so I've had to leave that in our `Makefile`
for now. I've filed https://github.com/mvdan/sh/issues/819 upstream with
the `shfmt` folks asking about this.