### PR TITLE
Handle special characters in the watch patch.

### DIFF
--- a/lib/commands/command.bash
+++ b/lib/commands/command.bash
@@ -140,7 +140,7 @@ _load_plugin_version_and_file() {
     _plugin_env_bash "$plugin_name" "$version"
   done
   if [ -f "$path" ]; then
-    echo watch_file "$path"
+    printf 'watch_file %q\n' "$path"
   fi
 }
 


### PR DESCRIPTION
Handle special characters in the watch patch.

This fixes https://github.com/asdf-community/asdf-direnv/issues/67. All
credit for this fix should go to @MaienM. I had no idea `printf` had
this `%q` formatter, it's terribly useful!

Regarding portability: this is not my area of expertise, but this seems
to work fine for me on Linux and macOS:

Linux with Bash 5.1.16:

    ➜  ~ bash --version && bash
    GNU bash, version 5.1.16(1)-release (x86_64-pc-linux-gnu)
    Copyright (C) 2020 Free Software Foundation, Inc.
    License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

    This is free software; you are free to change and redistribute it.
    There is NO WARRANTY, to the extent permitted by law.
    $ uname
    Linux
    $ printf "escaped: %q\n" "hello's world"
    escaped: hello\'s\ world

macOS with Bash 3.2:

    jeremy@Jeremys-MacBook-Pro ~ % bash --version && bash
    GNU bash, version 3.2.57(1)-release (arm64-apple-darwin21)
    Copyright (C) 2007 Free Software Foundation, Inc.

    The default interactive shell is now zsh.
    To update your account to use zsh, please run `chsh -s /bin/zsh`.
    For more details, please visit https://support.apple.com/kb/HT208050.
    bash-3.2$ uname
    Darwin
    bash-3.2$ printf "escaped: %q\n" "hello's world"
    escaped: hello\'s\ world

    Linux with bash 5.1.16
