### PR TITLE
Use a different directory for cached envrc files.

### DIFF
--- a/lib/commands/command.bash
+++ b/lib/commands/command.bash
@@ -16,9 +16,17 @@ _load_asdf_utils() {
   fi
 }
 
+_cache_dir() {
+  XDG_CACHE_HOME=${XDG_CACHE_HOME:-$HOME/.cache}
+  local dir
+  dir=$XDG_CACHE_HOME/asdf-direnv
+  mkdir -p "$dir"
+  echo "$dir"
+}
+
 _asdf_cached_envrc() {
   local dump_dir tools_file tools_cksum env_file
-  dump_dir="$(asdf where direnv)/env"
+  dump_dir="$(_cache_dir)/env"
   tools_file="$(_local_versions_file)"
   tools_cksum="$(_cksum "$tools_file" "$@")"
   env_file="$dump_dir/$tools_cksum"


### PR DESCRIPTION
This fixes https://github.com/asdf-community/asdf-direnv/issues/103.

Previously, we were putting the cached envrc files in a direnv specific
directory. This worked if `asdf where direnv` actually returns
a legitimate directory, but when you're using a system install of
direnv, `asdf where direnv` just prints out something like "System
version is selected", and that's not a directory we can work with.

I opted to allocate ourselves a directory under `XDG_CACHE_HOME`, which
has the nice property of always working, and also feels more appropriate
to me: these files aren't really a direnv thing, they're an
`asdf-direnv` thing.