### PR TITLE
Custom plugin shims now lower in PATH than bins

### DIFF
--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -125,8 +125,8 @@ teardown() {
   # plugin bin at head of PATH
   path_as_lines
   path_as_lines | sed -n 1p | grep "direnv"
-  path_as_lines | sed -n 2p | grep "$(dummy_shims_path dummy 1.0)"
-  path_as_lines | sed -n 3p | grep "$(dummy_bin_path dummy 1.0)"
+  path_as_lines | sed -n 2p | grep "$(dummy_bin_path dummy 1.0)"
+  path_as_lines | sed -n 3p | grep "$(dummy_shims_path dummy 1.0)"
 }
 
 @test "use asdf - exports plugin custom env not only PATH" {


### PR DESCRIPTION
We no longer use asdf's `with_plugin_env`, since
it by default prepends custom-shims higher in path
which caused some issues as documented on #82.

We still add the shims directory (we had a test for
this) but now just after the actual installed bins.

We also use `source_env` to load the plugin's `exec-env`
with the added benefit that direnv will watch the file
for changes and re-trigger if people upgrade the plugin.


Fixes #82