### PR TITLE
Add `ASDF_DIRENV_DEBUG` to the tools file checksum.

### DIFF
--- a/lib/commands/command.bash
+++ b/lib/commands/command.bash
@@ -61,7 +61,7 @@ _asdf_cached_envrc() {
   dump_dir="$(_cache_dir)/env"
   generating_dump_dir="$(_cache_dir)/env-generating"
   tools_file="$(_local_versions_file)"
-  tools_cksum="$(_cksum "$tools_file" "$@")"
+  tools_cksum="$(_cksum "$tools_file" "$ASDF_DIRENV_DEBUG" "$@")"
   env_file="$dump_dir/$tools_cksum"
 
   if [ -f "$env_file" ] && [ -z "$ASDF_DIRENV_DEBUG" ]; then


### PR DESCRIPTION
In https://github.com/asdf-community/asdf-direnv/pull/110/, we changed
things so the generated envrc file is different based on if the
`ASDF_DIRENV_DEBUG` environment variable is set. Before this change, if
you were to generate a cached file while this env var is set, when you
switch the env var off, you'd *still* have a `set -x` in your cached
envrc file.