### PR TITLE
Do not add plugin paths for "system" versions

### DIFF
--- a/lib/commands/command.bash
+++ b/lib/commands/command.bash
@@ -235,8 +235,11 @@ _plugin_env_bash() {
   # Add plugin bin_paths to PATH. We add them in reverse order to preserve original PATH.
   # NOTE: The plugin returns a list of space-separated dirs relative to install_dir.
   # NOTE: We don't add custom shims into path.
-  list_plugin_bin_paths "$plugin_name" "$version" "$install_type" |
-    tr $' ' $'\n' | _tail_r | sed -e "s#^#$install_path/#" | _each_do echo PATH_add
+  # NOTE: If install_path is empty (ex. "system" version), skip this step so /bin doesn't get added to PATH.
+  if [ -n "$install_path" ]; then
+    list_plugin_bin_paths "$plugin_name" "$version" "$install_type" |
+      tr $' ' $'\n' | _tail_r | sed -e "s#^#$install_path/#" | _each_do echo PATH_add
+  fi
 
   # If the plugin defines custom environment, source it.
   if [ -f "${plugin_path}/bin/exec-env" ]; then


### PR DESCRIPTION
I have `direnv` installed as a `system` version in `asdf`. With the current `asdf-direnv`, `/bin` ends up in my `PATH` before the original `PATH` entries. I use `coreutils` via homebrew instead of the BSD equivalents, and `/bin` coming before them causes some errors in my environment. This happens because when the cached env file is generated, `install_path` is an empty string for `system` plugins, `/bin` is appended to that `install_path`, and `PATH_add /bin` is added to the cached env file. Here is an env file that was created with the latest `asdf-direnv`:

```
log_status using asdf python 3.9.10
PATH_add /Users/bryan/.local/share/asdf/installs/python/3.9.10/bin
log_status using asdf direnv system
PATH_add /bin
watch_file /Users/bryan/.tool-versions
```

Surrounding the routine to add plugin `bin_paths` to `PATH` with a null string check of `install_path` fixes this issue for me.