### PR TITLE
RFC: Add a new `asdf direnv shell` command

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install bats-core
         run: |
-          git clone --depth 1 --branch v1.1.0 https://github.com/bats-core/bats-core.git $HOME/bats-core
+          git clone --depth 1 --branch v1.5.0 https://github.com/bats-core/bats-core.git $HOME/bats-core
           echo "$HOME/bats-core/bin" >>"$GITHUB_PATH"
 
       - name: Run tests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install bats-core
         run: |
-          git clone --depth 1 --branch v1.5.0 https://github.com/bats-core/bats-core.git $HOME/bats-core
+          git clone --depth 1 --branch v1.6.0 https://github.com/bats-core/bats-core.git $HOME/bats-core
           echo "$HOME/bats-core/bin" >>"$GITHUB_PATH"
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 Please update it as part of your Pull-Request. Add a new entry at the top of the `Unreleased` section.
-Try to keep it short. Just a single line and the number of your PR/Issues. 
+Try to keep it short. Just a single line and the number of your PR/Issues.
 All other relevant information should be provided on related issues or the PR itself.
 
 When creating a new release, just create another section and include a link to the release and a
 github compare-link with the previous one.
 
 ## [Unreleased](https://github.com/asdf-community/asdf-direnv/compare/v0.2.0..master)
+
+- Add a `asdf direnv shell` command that acts similar to the shims-based `asdf shell` command. #117
 
 - Add `asdf direnv setup` and `asdf direnv local`. #122
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,6 @@ lint:
 .PHONY: lint
 
 test:
-	bats test
+	env TERM=xterm bats -F tap test
 .PHONY: test
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ hyperfine --cleanup 'npm uninstall -g yarn' 'npm install -g yarn'
 ```bash
 # ~/.bashrc or equivalent
 
-# Dont source `~/.asdf/asdf.sh`
+# Don't source `~/.asdf/asdf.sh`
 PATH="$PATH:~/.asdf/bin"
 source "~/.asdf/lib/asdf.sh" # just load the asdf wrapper function
 ```

--- a/README.md
+++ b/README.md
@@ -183,6 +183,25 @@ Finally, run `direnv allow` to trust your new file.
 </details>
 
 <details>
+  <summary><h4>Temporary environments for one-shot commands</h4></summary>
+
+  Some times you just want to execute a one-shot commmand under certain
+  environment without creating/modifying `.envrc` and `.tool-versions` files
+  on your project directory. In those cases, you might want to try using
+  `asdf direnv shell`.
+
+
+``` bash
+# Enter a new shell having python and node
+$ asdf direnv shell python 3.8.10 nodejs 14.18.2
+
+# Just execute a npx command under some node version.
+$ asdf direnv shell nodejs 14.18.2 -- npx create-react-app
+```
+
+</details>
+
+<details>
   <summary><h6>Cached environment</h6></summary>
 
 To speed up things a lot, this plugin creates direnv `envrc` files that contain
@@ -348,9 +367,6 @@ watch_file "package.json"
   fails you will see more output.
   
 </details>
-
-- Sad that `asdf shell` doesn't work anymore? Try out `asdf direnv shell`
-  instead.
 
 ## Useful links
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ watch_file "package.json"
   
 </details>
 
+- Sad that `asdf shell` doesn't work anymore? Try out `asdf direnv shell`
+  instead.
+
 ## Useful links
 
 Read [direnv documentation](https://direnv.net/) for more on `.envrc`

--- a/lib/commands/command-shell.bash
+++ b/lib/commands/command-shell.bash
@@ -37,7 +37,7 @@ run_with_plugins() {
 
     if [ $# -eq 0 ]; then
       log_error "Please specify a version for $plugin."
-      return 1
+      exit 1
     fi
     version="$1"
     shift
@@ -60,9 +60,9 @@ run_with_plugins() {
   done
 
   if [ $# -eq 0 ]; then
-    $SHELL
+    exec $SHELL
   else
-    "$@"
+    exec "$@"
   fi
 }
 

--- a/lib/commands/command-shell.bash
+++ b/lib/commands/command-shell.bash
@@ -32,6 +32,8 @@ run_with_plugins() {
       break
     fi
 
+    local plugin version
+
     plugin="$1"
     shift
 

--- a/lib/commands/command-shell.bash
+++ b/lib/commands/command-shell.bash
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Exit on error, since this is an executable and not a sourced file.
+set -eo pipefail
+
+if [ -n "$ASDF_DIRENV_DEBUG" ]; then
+  set -x
+fi
+
+# shellcheck source=lib/commands/command.bash
+source "$(dirname "${BASH_SOURCE[0]}")/command.bash"
+
+if [ $# -eq 0 ]; then
+  echo "Usage: asdf direnv shell <name> <version> [<name> <version>]..."
+  echo ""
+  echo "Example:"
+  echo ""
+  echo "$ asdf direnv shell python 3.8.10 nodejs 14.18.2"
+  exit 1
+fi
+
+load_plugins() {
+  while [ $# -gt 0 ]; do
+    plugin="$1"
+    shift
+    if [ $# -eq 0 ]; then
+      log_error "Please specify a version for $plugin."
+      exit 1
+    fi
+    version="$1"
+    shift
+    echo "Loading $plugin $version" >/dev/stderr
+
+    # Set the appropriate ASDF_*_VERSION environment variable. This isn't
+    # strictly necessary because we're not using shims, but it's nice because
+    # it'll get `asdf current` to print out useful information, and if folks
+    # have a special prompt configured (such as powerlevel10k), it'll know
+    # about the newly activated tools.
+    #
+    # (this logic was copied from lib/commands/command-export-shell-version.bash)
+    local upcase_name
+    upcase_name=$(tr '[:lower:]-' '[:upper:]_' <<<"$plugin")
+    local version_env_var="ASDF_${upcase_name}_VERSION"
+    export "$version_env_var"="$version"
+
+    eval "$(_plugin_env_bash "$plugin" "$version" "$plugin $version not installed. Run 'asdf install $plugin $version' and try again.")"
+  done
+}
+
+load_plugins "$@"
+
+$SHELL

--- a/lib/commands/command.bash
+++ b/lib/commands/command.bash
@@ -221,7 +221,7 @@ _load_plugin_version_and_file() {
 
   for version in "${versions[@]}"; do
     echo log_status "using asdf ${plugin_name} ${version}"
-    _plugin_env_bash "$plugin_name" "$version"
+    _plugin_env_bash "$plugin_name" "$version" "$plugin $version not installed. Run 'asdf install' and then 'direnv reload'."
   done
   if [ -f "$path" ]; then
     printf 'watch_file %q\n' "$path"
@@ -247,6 +247,7 @@ _direnv_bash_dump() {
 _plugin_env_bash() {
   local plugin="${1}"
   local version="${2}"
+  local not_installed_message="${3}"
 
   # NOTE: unlike asdf, asdf-direnv does not support other installation types.
   local install_type="version"
@@ -259,7 +260,7 @@ _plugin_env_bash() {
   if [ "$version" != "system" ]; then
     install_path=$(get_install_path "$plugin" "$install_type" "$version")
     if [ ! -d "$install_path" ]; then
-      log_error "$plugin $version not installed. Run 'asdf install' and then 'direnv reload'."
+      log_error "$not_installed_message"
       exit 1
     fi
   fi
@@ -284,11 +285,13 @@ _plugin_env_bash() {
   fi
 }
 
-case "$1" in
-  "_"*)
-    "$@"
-    ;;
-  *)
-    exec "$direnv" "$@"
-    ;;
-esac
+if [ "$0" == "${BASH_SOURCE[0]}" ]; then
+  case "$1" in
+    "_"*)
+      "$@"
+      ;;
+    *)
+      exec "$direnv" "$@"
+      ;;
+  esac
+fi

--- a/lib/commands/command.bash
+++ b/lib/commands/command.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Exit on error, since this is an executable an not a sourced file.
+# Exit on error, since this is an executable and not a sourced file.
 set -eo pipefail
 
 if [ -n "$ASDF_DIRENV_DEBUG" ]; then

--- a/test/shell_command.bats
+++ b/test/shell_command.bats
@@ -28,7 +28,6 @@ teardown() {
 
 @test "calling with plugin name but without version fails" {
   run asdf direnv shell dummy
-  echo "$output" # debugging CI
   [ "$status" -eq 1 ]
   echo "$output" | grep "Please specify a version for dummy"
 }

--- a/test/shell_command.bats
+++ b/test/shell_command.bats
@@ -28,7 +28,8 @@ teardown() {
 
 @test "calling with plugin name but without version fails" {
   run asdf direnv shell dummy
-  [ "$status" -gt 0 ]
+  echo "$output" # debugging CI
+  [ "$status" -eq 1 ]
   echo "$output" | grep "Please specify a version for dummy"
 }
 

--- a/test/shell_command.bats
+++ b/test/shell_command.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# -*- shell-script -*-
+
+load test_helpers
+
+setup() {
+  setup_asdf_direnv
+}
+
+teardown() {
+  clean_asdf_direnv
+}
+
+@test "calling without arguments prints help" {
+  run asdf direnv shell
+  echo "$output" | grep "Usage: asdf direnv shell"
+}
+
+@test "calling with --help prints help" {
+  run asdf direnv shell --help
+  echo "$output" | grep "Usage: asdf direnv shell"
+}
+
+@test "calling with -h prints help" {
+  run asdf direnv shell -h
+  echo "$output" | grep "Usage: asdf direnv shell"
+}
+
+@test "calling with plugin name but without version fails" {
+  run asdf direnv shell dummy
+  [ "$status" -gt 0 ]
+  echo "$output" | grep "Please specify a version for dummy"
+}
+
+@test "can specify a one-shot command to run" {
+  install_dummy_plugin dummy 1.0
+  run asdf direnv shell dummy 1.0 -- dummy
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" == "direnv: using asdf dummy 1.0" ]
+  [ "${lines[1]}" == "This is dummy 1.0" ]
+}


### PR DESCRIPTION
Last week, I learned that @chris-lasher-honor used to be an
`asdf-direnv` user, but switched back to plain `asdf` because he liked
using `asdf shell` for small one-off commands like `npx
create-react-app`. I think that's a pretty solid use-case where it's not
necessarily worth the overhead of creating a `.tool-versions` file and a
`.envrc` file just to create a brand new folder that's going to also needs
its own set of the same dotfiles.

I also sometimes find that the activation energy necessary just to play
around with a random tool is a bit high with asdf-direnv:

- create a new directory
- run `asdf local <plugin> <version>`
- create a `.envrc` file
- run `direnv allow`

Now, you can do something like `asdf shell python 3.8.10`, and be up and
running immediately:

    $ asdf current
    direnv          2.30.3          /home/jeremy/.tool-versions
    nodejs          ______          No version is set. Run "asdf <global|shell|local> nodejs <version>"
    $ node --version
    bash: node: command not found
 
    $ asdf direnv shell nodejs 10.17.0
    Loading nodejs 10.17.0
    direnv: loading ~/.asdf/plugins/nodejs/bin/exec-env
 
    $ asdf current
    direnv          2.30.3          /home/jeremy/.tool-versions
    nodejs          10.17.0         ASDF_NODEJS_VERSION environment variable
    $ node --version
    v10.17.0