### PR TITLE
Add `asdf direnv setup` and `asdf direnv local`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .tool-versions
+.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ github compare-link with the previous one.
 
 ## [Unreleased](https://github.com/asdf-community/asdf-direnv/compare/v0.2.0..master)
 
+- Add `asdf direnv setup` and `asdf direnv local`. #122
+
 - Document `ASDF_DIRENV_BIN` variable used to avoid doing direnv version resolution. #121
 
 - Speed up direnv stdlib by trying not to use asdf exec. #120

--- a/README.md
+++ b/README.md
@@ -89,18 +89,23 @@ expected location. Also, no more _reshim_ needed upon `npm install`.
 
 ## Usage
 
-<details open>
-  <summary><h3>Setup</h3></summary>
+### Setup
 
-First, make sure you install this plugin, which will make all the
-`asdf direnv` subcommands available to you:
+Install this plugin and run the automatic setup: `asdf direnv setup`.
+You can run this command for all of your preferred shells `bash`/`fish`/`zsh`.
 
 ```bash
 asdf plugin-add direnv
-asdf help # you should see `asdf direnv` commands listed here.
+asdf direnv setup bash
 ```
 
-Then, make sure you have [direnv](https://direnv.net/) installed.
+The automatic setup follows the steps documented bellow in the manual section,
+and will hint which files were modified, you might want to review its changes.
+
+<details>
+  <summary><h6>System Manual Setup</h6></summary>
+
+Make sure you have [direnv](https://direnv.net/) installed.
 You can either use your system package manager or asdf to install it:
 
 ```bash
@@ -146,8 +151,20 @@ source "$(asdf direnv hook asdf)"
   
 </details>
 
-<details open>
-  <summary><h4>Per-Project setup</h4></summary>
+### Per-Project setup
+
+The `asdf direnv local` command lets you install plugins, tool-versions, and activate
+your environment, all in a single command.
+
+
+``` bash
+asdf direnv local [<tool> <version>]...
+```
+
+<details>
+  <summary><h6>Per-Project Manual setup</h6></summary>
+
+Create a `.tool-versions` file either manually or using the `asdf local` command.
 
 ##### The .envrc file in your project root.
 

--- a/lib/commands/command-local.bash
+++ b/lib/commands/command-local.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Exit on error, since this is an executable an not a sourced file.
+set -eo pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/../setup-lib.bash"
+local_command "${@}"

--- a/lib/commands/command-setup.bash
+++ b/lib/commands/command-setup.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Exit on error, since this is an executable an not a sourced file.
+set -eo pipefail
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/../setup-lib.bash"
+setup_command "$@"

--- a/lib/setup-lib.bash
+++ b/lib/setup-lib.bash
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+
+if [ -n "$ASDF_DIRENV_DEBUG" ]; then
+  set -x
+fi
+
+function ok() {
+  echo -n "✔️" >&2
+  if test -n "$*"; then
+    echo -n "  $*" >&2
+  fi
+  echo >&2
+}
+
+function hmm() {
+  echo -n "❗️" >&2
+  if test -n "$*"; then
+    echo -n " $*" >&2
+  fi
+  echo >&2
+  return 1
+}
+
+function fail() {
+  echo -n "❌" >&2
+  if test -n "$*"; then
+    echo -n "  $*" >&2
+  fi
+  echo >&2
+  exit 1
+}
+
+function prompt() {
+  local input default
+  if test -n "$1"; then
+    echo -n "⌨  $1: " >&2
+    shift
+  fi
+  default="$1"
+  read -r input
+  if test -n "$input"; then
+    echo "$input"
+  else
+    echo "$default"
+  fi
+}
+
+function run_cmd() {
+  echo -n "▶ $* # ...  " >&2
+  if "${@}"; then
+    ok
+  else
+    local status="$?"
+    hmm "Failed with status $status"
+    return "$status"
+  fi
+}
+
+function maybe_run_cmd() {
+  echo -n "▶ $* # ...  " >&2
+  "${@}" || true
+  ok
+}
+
+function modifying() {
+  echo -n "✍  Modifying $1 " >&2
+  if echo "$2" >>"$1"; then
+    ok
+  else
+    fail
+  fi
+}
+
+function grep_or_add() {
+  local file content
+  file="$1"
+  shift
+  read -d $'\0' -r content
+  if grep -s "$content" "$file" >&2 >/dev/null; then
+    ok "$file looks fine"
+    return 0
+  else
+    mkdir -p "$(dirname "$file")"
+    modifying "$file" "$content"
+  fi
+}
+
+function check_for() {
+  echo "Checking for $1..." >&2
+  shift
+  "$@"
+}
+
+function asdf_bin_in_path() {
+  local bin
+  bin="$(command -v asdf 2>/dev/null)"
+  if test -x "$bin"; then
+    ok "Found asdf at $(command -v asdf)"
+  fi
+}
+
+function installed_direnv() {
+  local bin
+  bin="${ASDF_DIRENV_BIN:-$(asdf which direnv 2>/dev/null || true)}"
+  if test -x "$bin"; then
+    ASDF_DIRENV_BIN="$bin"
+  else
+    local version
+    version="$(prompt "Please specify a direnv version to use [version-number/latest/SYSTEM]" "system")"
+    case "$version" in
+      system | SYSTEM | "")
+        ASDF_DIRENV_BIN="$(run_cmd env ASDF_DIRENV_VERSION=system asdf which direnv)"
+        ;;
+      latest | LATEST)
+        run_cmd asdf install direnv latest
+        version="$(asdf list direnv | tail -n 1 | sed -e 's/ //g')" # since `ASDF_DIRENV_VERSION=latest asdf which direnv` does not work
+        ASDF_DIRENV_BIN="$(run_cmd env ASDF_DIRENV_VERSION="$version" asdf which direnv)"
+
+        ;;
+      *)
+        run_cmd asdf install direnv "$version"
+        ASDF_DIRENV_BIN="$(run_cmd env ASDF_DIRENV_VERSION="$version" asdf which direnv)"
+        ;;
+    esac
+  fi
+  test -x "$ASDF_DIRENV_BIN"
+  ok "Found direnv at ${ASDF_DIRENV_BIN}"
+  export ASDF_DIRENV_BIN
+}
+
+function direnv_shell_integration() {
+  local rcfile
+  case "${ASDF_DIRENV_SHELL:-$SHELL}" in
+    *bash*)
+      rcfile="$HOME/.bashrc"
+      cat <<-EOF | grep_or_add "$rcfile"
+export ASDF_DIRENV_BIN="$ASDF_DIRENV_BIN"
+eval "\$($ASDF_DIRENV_BIN hook bash)"
+EOF
+      ;;
+    *zsh*)
+      rcfile="$HOME/.zshrc"
+      cat <<-EOF | grep_or_add "$rcfile"
+export ASDF_DIRENV_BIN="$ASDF_DIRENV_BIN"
+eval "\$($ASDF_DIRENV_BIN hook zsh)"
+EOF
+      ;;
+    *fish*)
+      rcfile="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/asdf_direnv.fish"
+      cat <<-EOF | grep_or_add "$rcfile"
+set -g ASDF_DIRENV_BIN "$ASDF_DIRENV_BIN"
+$ASDF_DIRENV_BIN hook fish | source
+EOF
+      ;;
+    *)
+      fail "Don't know how to setup for shell $SHELL. PR welcome!"
+      ;;
+  esac
+}
+
+function direnv_asdf_integration() {
+  local rcfile="${XDG_CONFIG_HOME:-$HOME/.config}/direnv/direnvrc"
+  cat <<-EOF | grep_or_add "$rcfile"
+source "\$(asdf direnv hook asdf)"
+
+# Uncomment the following line to make direnv silent by default.
+# export DIRENV_LOG_FORMAT=""
+EOF
+}
+
+function setup_command() {
+  if test -n "$1"; then
+    export ASDF_DIRENV_SHELL="$1"
+  fi
+
+  check_for "asdf" asdf_bin_in_path || fail "Make sure you have asdf installed. Follow instructions at https://asdf-vm.com"
+  check_for "direnv" installed_direnv || fail "An installation of direnv is required to continue. See https://github.com/asdf-community/asdf-direnv"
+  check_for "direnv shell integration" direnv_shell_integration || fail "direnv shell hook must be installed. See https://direnv.net/docs/hook.html"
+  check_for "direnv asdf integration" direnv_asdf_integration || fail "asdf-direnv function must be installed on direnvrc. See https://github.com/asdf-community/asdf-direnv"
+}
+
+function local_command() {
+  local plugin version
+  while [ $# -gt 0 ]; do
+    plugin="$1"
+    shift
+
+    if [ $# -eq 0 ]; then
+      fail "Please specify a version for $plugin.\n" >&2
+    fi
+    version="$1"
+    shift
+
+    maybe_run_cmd asdf plugin-add "$plugin"
+    run_cmd asdf install "$plugin" "$version"
+    run_cmd asdf local "$plugin" "$version"
+  done
+
+  printf "use asdf\n\0" | grep_or_add ".envrc"
+  run_cmd direnv allow
+}

--- a/test/local_command.bats
+++ b/test/local_command.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+# -*- shell-script -*-
+
+load test_helpers
+
+setup() {
+  setup_asdf_direnv
+}
+
+teardown() {
+  clean_asdf_direnv
+}
+
+@test "local command touches .tool-versions and .envrc" {
+  install_dummy_plugin "dummy" "1.0"
+
+  run asdf direnv setup bash
+  run asdf direnv local dummy 1.0
+  grep "dummy 1.0" ".tool-versions"
+  grep "use asdf" ".envrc"
+
+  source "$HOME/.bashrc"
+  envrc_load
+  run dummy
+
+  [ "$output" = "This is dummy 1.0" ]
+}

--- a/test/local_command.bats
+++ b/test/local_command.bats
@@ -14,12 +14,11 @@ teardown() {
 @test "local command touches .tool-versions and .envrc" {
   install_dummy_plugin "dummy" "1.0"
 
-  run asdf direnv setup bash
   run asdf direnv local dummy 1.0
   grep "dummy 1.0" ".tool-versions"
   grep "use asdf" ".envrc"
 
-  source "$HOME/.bashrc"
+  envrc_use_asdf
   envrc_load
   run dummy
 

--- a/test/setup_command.bats
+++ b/test/setup_command.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# -*- shell-script -*-
+
+load test_helpers
+
+setup() {
+  setup_asdf_direnv
+}
+
+teardown() {
+  clean_asdf_direnv
+}
+
+@test "setup bash modifies rcfile" {
+  run asdf direnv setup bash
+  grep "export ASDF_DIRENV_BIN" "$HOME/.bashrc"
+  grep "direnv hook bash" "$HOME/.bashrc"
+  grep "asdf direnv hook asdf" "$XDG_CONFIG_HOME/direnv/direnvrc"
+}
+
+@test "setup zsh modifies rcfile" {
+  run asdf direnv setup zsh
+  grep "export ASDF_DIRENV_BIN" "$HOME/.zshrc"
+  grep "direnv hook zsh" "$HOME/.zshrc"
+  grep "asdf direnv hook asdf" "$XDG_CONFIG_HOME/direnv/direnvrc"
+}
+
+@test "setup fish modifies rcfile" {
+  run asdf direnv setup fish
+  grep "set -g ASDF_DIRENV_BIN" "$XDG_CONFIG_HOME/fish/conf.d/asdf_direnv.fish"
+  grep "direnv hook fish" "$XDG_CONFIG_HOME/fish/conf.d/asdf_direnv.fish"
+  grep "asdf direnv hook asdf" "$XDG_CONFIG_HOME/direnv/direnvrc"
+}

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -24,9 +24,13 @@ setup_asdf_direnv() {
 
   BASE_DIR=$(mktemp -dt asdf.XXXX)
   HOME=$BASE_DIR/home
+  XDG_CONFIG_HOME="$HOME/.config"
+  XDG_CACHE_HOME="$HOME/.cache"
   ASDF_DIR="$HOME/.asdf"
   ASDF_DATA_DIR="$ASDF_DIR"
   PATH="${ASDF_DIR}/bin:$PATH_WITHOUT_ASDF" # NOTE: dont add shims directory to PATH
+
+  mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME"
 
   mkdir -p "${ASDF_DIR}"/{bin,lib}
   mkdir -p "${ASDF_DATA_DIR}"/{plugins,installs,shims}


### PR DESCRIPTION
These commands follow our documented steps for setting up
asdf-direnv, both on system setup and on per-project.

The motivation is to lower the amount of work new people
has to do in order to get started with asdf-direnv.

