### PR TITLE
fix: export direnv bin

### DIFF
--- a/lib/setup-lib.bash
+++ b/lib/setup-lib.bash
@@ -148,7 +148,7 @@ EOF
     *fish*)
       rcfile="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/asdf_direnv.fish"
       cat <<-EOF | grep_or_add "$rcfile"
-set -g ASDF_DIRENV_BIN "$ASDF_DIRENV_BIN"
+set -gx ASDF_DIRENV_BIN "$ASDF_DIRENV_BIN"
 $ASDF_DIRENV_BIN hook fish | source
 EOF
       ;;


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Fixes

```
No direnv executable found. Please do one of the following:

With a system installed direnv

    export ASDF_DIRENV_BIN="$(command -v direnv)"

With an asdf installed direnv

    export ASDF_DIRENV_BIN="$(asdf which direnv)"
```

<!-- Please also add a CHANGELOG.md entry as part of your pull-request. -->

## Other Information

<!-- If there is anything else that is relevant please include it here. -->

<!-- Thank you for contributing to asdf-direnv! -->
