### PR TITLE
DRY up the config a bit.

### DIFF
--- a/lib/setup-lib.bash
+++ b/lib/setup-lib.bash
@@ -135,21 +135,21 @@ function direnv_shell_integration() {
       rcfile="$HOME/.bashrc"
       cat <<-EOF | grep_or_add "$rcfile"
 export ASDF_DIRENV_BIN="$ASDF_DIRENV_BIN"
-eval "\$($ASDF_DIRENV_BIN hook bash)"
+eval "\$(\$ASDF_DIRENV_BIN hook bash)"
 EOF
       ;;
     *zsh*)
       rcfile="$HOME/.zshrc"
       cat <<-EOF | grep_or_add "$rcfile"
 export ASDF_DIRENV_BIN="$ASDF_DIRENV_BIN"
-eval "\$($ASDF_DIRENV_BIN hook zsh)"
+eval "\$(\$ASDF_DIRENV_BIN hook zsh)"
 EOF
       ;;
     *fish*)
       rcfile="${XDG_CONFIG_HOME:-$HOME/.config}/fish/conf.d/asdf_direnv.fish"
       cat <<-EOF | grep_or_add "$rcfile"
 set -gx ASDF_DIRENV_BIN "$ASDF_DIRENV_BIN"
-$ASDF_DIRENV_BIN hook fish | source
+\$ASDF_DIRENV_BIN hook fish | source
 EOF
       ;;
     *)

--- a/test/setup_command.bats
+++ b/test/setup_command.bats
@@ -14,20 +14,20 @@ teardown() {
 @test "setup bash modifies rcfile" {
   run asdf direnv setup bash
   grep "export ASDF_DIRENV_BIN" "$HOME/.bashrc"
-  grep "direnv hook bash" "$HOME/.bashrc"
+  grep -F 'eval "$($ASDF_DIRENV_BIN hook bash)"' "$HOME/.bashrc"
   grep "asdf direnv hook asdf" "$XDG_CONFIG_HOME/direnv/lib/use_asdf.sh"
 }
 
 @test "setup zsh modifies rcfile" {
   run asdf direnv setup zsh
   grep "export ASDF_DIRENV_BIN" "$HOME/.zshrc"
-  grep "direnv hook zsh" "$HOME/.zshrc"
+  grep -F 'eval "$($ASDF_DIRENV_BIN hook zsh)"' "$HOME/.zshrc"
   grep "asdf direnv hook asdf" "$XDG_CONFIG_HOME/direnv/lib/use_asdf.sh"
 }
 
 @test "setup fish modifies rcfile" {
   run asdf direnv setup fish
   grep "set -gx ASDF_DIRENV_BIN" "$XDG_CONFIG_HOME/fish/conf.d/asdf_direnv.fish"
-  grep "direnv hook fish" "$XDG_CONFIG_HOME/fish/conf.d/asdf_direnv.fish"
+  grep -F '$ASDF_DIRENV_BIN hook fish' "$XDG_CONFIG_HOME/fish/conf.d/asdf_direnv.fish"
   grep "asdf direnv hook asdf" "$XDG_CONFIG_HOME/direnv/lib/use_asdf.sh"
 }


### PR DESCRIPTION
We're already setting a `ASDF_DIRENV_BIN` environment variable, it's
quite straightforward to reuse. I think this will make life a little easier
when people are upgrading direnv.

Before
======

Note how the full path to direnv (including the 2.31.0 version number)
shows up twice here:

    $ asdf direnv setup fish
    $ cat /home/jeremy/.config/fish/conf.d/asdf_direnv.fish
    set -gx ASDF_DIRENV_BIN "/home/jeremy/.asdf/installs/direnv/2.31.0/bin/direnv"
    /home/jeremy/.asdf/installs/direnv/2.31.0/bin/direnv hook fish | source

After
=====

    $ asdf direnv setup fish
    $ cat /home/jeremy/.config/fish/conf.d/asdf_direnv.fish
    set -gx ASDF_DIRENV_BIN "/home/jeremy/.asdf/installs/direnv/2.31.0/bin/direnv"
    $ASDF_DIRENV_BIN hook fish | source