### PR TITLE
Add support for resolving 'latest:X' in .tool-versions

### DIFF
--- a/lib/tools-environment-lib.bash
+++ b/lib/tools-environment-lib.bash
@@ -254,15 +254,16 @@ _plugin_env_bash() {
     exit 1
   fi
 
+  local version
+
   # The full_version may be of the form `latest:X`, so we resolve the latest
   # version here. This is the same method asdf itself uses; see
   # https://github.com/asdf-vm/asdf/blob/7493f4099c844e40af72d7f05635d7991a463d1a/lib/commands/command-install.bash#L161
   IFS=':' read -r -a version_info <<<"$full_version"
   if [ "${version_info[0]}" = "latest" ]; then
-    local version
     version=$(asdf latest "$plugin_name" "${version_info[1]}")
   else
-    local version="${version_info[0]}"
+    version="${version_info[0]}"
   fi
 
   if [ "$version" != "system" ]; then

--- a/lib/tools-environment-lib.bash
+++ b/lib/tools-environment-lib.bash
@@ -242,7 +242,7 @@ _direnv_bash_dump() {
 
 _plugin_env_bash() {
   local plugin="${1}"
-  local version="${2}"
+  local full_version="${2}"
   local not_installed_message="${3}"
 
   # NOTE: unlike asdf, asdf-direnv does not support other installation types.
@@ -253,6 +253,18 @@ _plugin_env_bash() {
     log_error "asdf plugin not installed: $plugin"
     exit 1
   fi
+
+  # The full_version may be of the form `latest:X`, so we resolve the latest
+  # version here. This is the same method asdf itself uses; see
+  # https://github.com/asdf-vm/asdf/blob/7493f4099c844e40af72d7f05635d7991a463d1a/lib/commands/command-install.bash#L161
+  IFS=':' read -r -a version_info <<<"$full_version"
+  if [ "${version_info[0]}" = "latest" ]; then
+    local version
+    version=$(asdf latest "$plugin_name" "${version_info[1]}")
+  else
+    local version="${version_info[0]}"
+  fi
+
   if [ "$version" != "system" ]; then
     install_path=$(get_install_path "$plugin" "$install_type" "$version")
     if [ ! -d "$install_path" ]; then

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -90,20 +90,13 @@ install_dummy_plugin() {
 
   mkdir -p "${ASDF_DATA_DIR}/plugins/${plugin_name}/bin"
 
-  # keep track of versions installed in a versions.txt file
-  local version_file="${ASDF_DATA_DIR}/plugins/${plugin_name}/data/versions.txt"
-  mkdir -p "$(dirname "$version_file")"
-  echo "$version" >>"$version_file"
-
   # create a 'list-all' script
   local list_all_path="${ASDF_DATA_DIR}/plugins/${plugin_name}/bin/list-all"
-  if test -n "$list_all_path"; then
-    cat <<-EOF >"$list_all_path"
+  cat <<-EOF >"$list_all_path"
 #!/usr/bin/env bash
-xargs < "$version_file"
+echo 1.0 2.0 2.1
 EOF
-    chmod +x "$list_all_path"
-  fi
+  chmod +x "$list_all_path"
 
   if test -n "$shim"; then
     local plugin_shims

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -90,6 +90,21 @@ install_dummy_plugin() {
 
   mkdir -p "${ASDF_DATA_DIR}/plugins/${plugin_name}/bin"
 
+  # keep track of versions installed in a versions.txt file
+  local version_file="${ASDF_DATA_DIR}/plugins/${plugin_name}/data/versions.txt"
+  mkdir -p "$(dirname "$version_file")"
+  echo "$version" >>"$version_file"
+
+  # create a 'list-all' script
+  local list_all_path="${ASDF_DATA_DIR}/plugins/${plugin_name}/bin/list-all"
+  if test -n "$list_all_path"; then
+    cat <<-EOF >"$list_all_path"
+#!/usr/bin/env bash
+xargs < "$version_file"
+EOF
+    chmod +x "$list_all_path"
+  fi
+
   if test -n "$shim"; then
     local plugin_shims
     plugin_shims="${ASDF_DATA_DIR}/plugins/${plugin_name}/shims"

--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -159,17 +159,17 @@ EOF
 }
 
 @test "use asdf - resolves latest:X version from tool-versions" {
-  install_dummy_plugin dummy 1.0
   install_dummy_plugin dummy 2.0
+  install_dummy_plugin dummy 2.1
 
   cd "$PROJECT_DIR"
-  asdf global dummy 1.0
+  asdf global dummy 2.0
   asdf local dummy latest:2
   asdf direnv local
   envrc_load
 
   run dummy
-  [ "$output" == "This is dummy 2.0" ] # executable in path
+  [ "$output" == "This is dummy 2.1" ] # executable in path
 }
 
 @test "use asdf - watches tool-versions for changes" {

--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -158,6 +158,19 @@ EOF
   [ "$output" == "This is dummy 2.0" ] # executable in path
 }
 
+@test "use asdf - resolves latest:X version from tool-versions" {
+  install_dummy_plugin dummy 1.0
+  install_dummy_plugin dummy 2.0
+
+  cd "$PROJECT_DIR"
+  asdf global dummy 1.0
+  asdf local dummy latest:2
+  asdf direnv local
+  envrc_load
+
+  run dummy
+  [ "$output" == "This is dummy 2.0" ] # executable in path
+}
 
 @test "use asdf - watches tool-versions for changes" {
   install_dummy_plugin dummy 1.0


### PR DESCRIPTION
## Overview

asdf supports specifying a version like 'latest:3' which means the latest stable version, in the 3.x.y series of a program. This adds support for this feature in this plugin.

Also adds a test, and support for `list-all` in the test dummy plugin. `list-all` is called by asdf internally when using the 'latest:X' format.

### Example

`.tool-versions`:
```
shfmt latest:3
```

### Before

```
❯ direnv reload
direnv: using asdf
direnv: Creating env file /Users/amrox/.cache/asdf-direnv/env/2823755088-4041093217-1715707609-2415048703
direnv:  latest:3 not installed. Run 'asdf install' and then 'direnv reload'.
direnv: loading ~/.cache/asdf-direnv/env/2823755088-4041093217-1715707609-2415048703
direnv: using asdf shfmt latest:3
direnv: loading ~/tmp/asdf-direnv-latest/.envrc

❯ which shfmt
shfmt not found
```

### After

```
❯ direnv reload
direnv: using asdf
direnv: Creating env file /Users/amrox/.cache/asdf-direnv/env/2823755088-4041093217-3420899879-2415048703
direnv: loading ~/.cache/asdf-direnv/env/2823755088-4041093217-3420899879-2415048703
direnv: using asdf shfmt latest:3
direnv: loading ~/tmp/asdf-direnv-latest/.envrc
direnv: export ~PATH

❯ which shfmt
/Users/amrox/.asdf/installs/shfmt/3.4.3/bin/shfmt
```

## Implementation notes

- The technique used to translate 'latest:X' into an actual version is [the same as in asdf itself.](https://github.com/asdf-vm/asdf/blob/7493f4099c844e40af72d7f05635d7991a463d1a/lib/commands/command-install.bash#L161)

## Interesting/controversial decisions

- maybe adding `list-all` in the dummy test plugin?

## Test coverage

I included a new test, and support for 'list-all' in the dummy plugin. `list-all` is necessary to resolve the latest:X version.

New test is 22

```
❯ make test
env TERM=xterm bats -F tap test
1..28
ok 1 install command fails if the input is not version number
ok 2 local command touches .tool-versions and .envrc
ok 3 local command touches .tool-versions and .envrc - multiple tools
ok 4 setup bash modifies rcfile
ok 5 setup zsh modifies rcfile
ok 6 setup fish modifies rcfile
ok 7 can re-run setup
ok 8 calling without arguments prints help
ok 9 calling with --help prints help
ok 10 calling with -h prints help
ok 11 calling with plugin name but without version fails
ok 12 can specify a one-shot command to run
ok 13 dummy 1.0 is available via asdf exec
ok 14 direnv loads simple envrc
ok 15 use multiple versions for same plugin - multiline
ok 16 use multiple versions for same plugin - inline
ok 17 use asdf - makes global tools available in PATH
ok 18 use asdf - makes local tools available in PATH
ok 19 use asdf - prepends plugin custom shims to PATH
ok 20 use asdf - exports plugin custom env not only PATH
ok 21 use asdf - determines version from tool-versions
ok 22 use asdf - resolves latest:X version from tool-versions
ok 23 use asdf - watches tool-versions for changes
ok 24 use asdf - watches plugin legacy file for changes
ok 25 use asdf - activates currently selected plugins
ok 26 use asdf - watches selection files
ok 27 use asdf - watches legacy files
ok 28 use asdf - sets local tools on PATH before global tools
```

## Loose ends

 n/a