### PR TITLE
Use ZDOTDIR to find zshrc, if set.

### DIFF
--- a/lib/setup-lib.bash
+++ b/lib/setup-lib.bash
@@ -149,7 +149,7 @@ eval "\$(\$ASDF_DIRENV_BIN hook bash)"
 EOF
       ;;
     *zsh*)
-      rcfile="$HOME/.zshrc"
+      rcfile="${ZDOTDIR:-$HOME}/.zshrc"
       # shellcheck disable=SC2016
       asdf_direnv_rcfile_expr='${XDG_CONFIG_HOME:-$HOME/.config}/asdf-direnv/zshrc'
       asdf_direnv_rcfile=$(eval echo "$asdf_direnv_rcfile_expr")

--- a/test/setup_command.bats
+++ b/test/setup_command.bats
@@ -28,10 +28,22 @@ teardown() {
   grep -F "$EXPECTED_USE_ASDF" "$XDG_CONFIG_HOME/direnv/lib/use_asdf.sh"
 }
 
-@test "setup zsh modifies rcfile" {
+@test "setup zsh modifies rcfile (ZDOTDIR unset)" {
+  unset ZDOTDIR
   run asdf direnv setup --shell zsh --version system
   # shellcheck disable=SC2016
   grep -F '${XDG_CONFIG_HOME:-$HOME/.config}/asdf-direnv/zshrc' "$HOME/.zshrc"
+  grep "export ASDF_DIRENV_BIN" "$XDG_CONFIG_HOME/asdf-direnv/zshrc"
+  # shellcheck disable=SC2016
+  grep -F 'eval "$($ASDF_DIRENV_BIN hook zsh)"' "$XDG_CONFIG_HOME/asdf-direnv/zshrc"
+  grep -F "$EXPECTED_USE_ASDF" "$XDG_CONFIG_HOME/direnv/lib/use_asdf.sh"
+}
+
+@test "setup zsh modifies rcfile (ZDOTDIR set)" {
+  export ZDOTDIR="${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
+  run asdf direnv setup --shell zsh --version system
+  # shellcheck disable=SC2016
+  grep -F '${XDG_CONFIG_HOME:-$HOME/.config}/asdf-direnv/zshrc' "$HOME/.config/zsh/.zshrc"
   grep "export ASDF_DIRENV_BIN" "$XDG_CONFIG_HOME/asdf-direnv/zshrc"
   # shellcheck disable=SC2016
   grep -F 'eval "$($ASDF_DIRENV_BIN hook zsh)"' "$XDG_CONFIG_HOME/asdf-direnv/zshrc"


### PR DESCRIPTION
## Overview

This change allows the setup script to find the correct path to the zshrc file when [`ZDOTDIR`](https://zsh.sourceforge.io/Intro/intro_3.html) has been set.

## Implementation notes

This uses string substitution similar to the detection for the fish configuration file.

## Interesting/controversial decisions

N/A, I think.

## Test coverage

Added a test for `ZDOTDIR` being set.
Also ensured `ZDOTDIR` was unset for the original test.

## Loose ends

~I apologize, but I'm not actually sure how to run the tests.~ Perhaps consider adding a Development section to the README in the future? Or maybe I can add one once I figure some things out. Anyways, ❤️ for asdf-direnv.

**UPDATE**: I was able to figure out how to run the tests with `bats-core` installed. I'm not sure how to get a test where the zsh files are all rolled back between the two zsh tests, though. Maybe that's okay for now.
