### PR TITLE
Dont use asdf which to look for system executables

### DIFF
--- a/lib/setup-lib.bash
+++ b/lib/setup-lib.bash
@@ -129,7 +129,7 @@ function installed_direnv() {
       ;;
   esac
 
-  test -x "$ASDF_DIRENV_BIN"
+  test -x "$ASDF_DIRENV_BIN" || fail "No direnv found"
   ok "Found direnv at ${ASDF_DIRENV_BIN}"
   export ASDF_DIRENV_BIN
 }

--- a/lib/setup-lib.bash
+++ b/lib/setup-lib.bash
@@ -39,7 +39,7 @@ function run_cmd() {
   else
     local status="$?"
     hmm "Failed with status $status"
-    return "$status"
+    exit "$status"
   fi
 }
 
@@ -111,9 +111,11 @@ function asdf_bin_in_path() {
 
 function installed_direnv() {
   local version=$1
+  local path_without_asdf
   case "$version" in
     system | SYSTEM)
-      ASDF_DIRENV_BIN="$(run_cmd env ASDF_DIRENV_VERSION=system asdf which direnv)"
+      path_without_asdf="$(echo "$PATH" | tr ':' $'\n' | grep -v asdf | tr $'\n' ':' | sed -e 's#:$##')"
+      ASDF_DIRENV_BIN="$(run_cmd env PATH="$path_without_asdf" command -v direnv)"
       ;;
     latest | LATEST)
       run_cmd asdf install direnv latest

--- a/lib/setup-lib.bash
+++ b/lib/setup-lib.bash
@@ -111,11 +111,10 @@ function asdf_bin_in_path() {
 
 function installed_direnv() {
   local version=$1
-  local path_without_asdf
   case "$version" in
     system | SYSTEM)
-      path_without_asdf="$(echo "$PATH" | tr ':' $'\n' | grep -v asdf | tr $'\n' ':' | sed -e 's#:$##')"
-      ASDF_DIRENV_BIN="$(run_cmd env PATH="$path_without_asdf" command -v direnv)"
+      # Take only the first direnv that is not provided by asdf shims.
+      ASDF_DIRENV_BIN="$(which -a direnv | grep -v asdf | head -n 1)"
       ;;
     latest | LATEST)
       run_cmd asdf install direnv latest
@@ -129,7 +128,7 @@ function installed_direnv() {
       ;;
   esac
 
-  test -x "$ASDF_DIRENV_BIN" || fail "No direnv found"
+  test -x "$ASDF_DIRENV_BIN" || fail "No direnv executable found"
   ok "Found direnv at ${ASDF_DIRENV_BIN}"
   export ASDF_DIRENV_BIN
 }

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -29,9 +29,13 @@ env_setup() {
   ASDF_DIR="$HOME/.asdf"
   ASDF_DATA_DIR="$ASDF_DIR"
 
+  # A temporary "system" direnv binary outside of asdf.
+  DIRENV_SYS=$(mktemp -dt direnv.XXXX)
+  ln -s "$ASDF_WHERE_DIRENV/bin/direnv" "$DIRENV_SYS/direnv"
+
   # NOTE: dont add asdf shims directory to PATH
   # NOTE: we add direnv to PATH for testing system-installed direnv setup.
-  PATH="${ASDF_DIR}/bin:$PATH_WITHOUT_ASDF:${ASDF_WHERE_DIRENV}/bin"
+  PATH="${ASDF_DIR}/bin:$PATH_WITHOUT_ASDF:${DIRENV_SYS}"
 
   mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME"
 


### PR DESCRIPTION
Instead of using asdf which, we now ensure to remove asdf shims from PATH and run `command -v direnv`.

Because it looks like `env ASDF_DIRENV_VERSION=system asdf which direnv` only works if you already have an asdf shim for direnv.

Also, run_cmd should exit with error status on failure
instead of continue executing setup.

Fixes #141