### PR TITLE
Help users upgrading from <0.3.0 without already having run `asdf direnv setup`.

### DIFF
--- a/lib/commands/command-_asdf_cached_envrc.bash
+++ b/lib/commands/command-_asdf_cached_envrc.bash
@@ -4,7 +4,7 @@ set -eo pipefail
 
 # TODO: remove once we release 0.4.0
 cat <<-'EOF' >&2
-Looks like you are using the 'asdf direnv hook' command which was removed in asdf-direnv 0.3.0.
+Looks like you are using the 'asdf direnv _asdf_cached_envrc' command which was removed in asdf-direnv 0.3.0.
 
 You might want to run 'asdf direnv setup' again. See the README for instructions on updating.
 

--- a/lib/commands/command-hook-asdf.bash
+++ b/lib/commands/command-hook-asdf.bash
@@ -4,7 +4,7 @@ set -eo pipefail
 
 # TODO: remove once we release 0.4.0
 cat <<-'EOF' >&2
-Looks like you are using the 'asdf direnv hook' command which was removed in asdf-direnv 0.3.0.
+Looks like you are using the 'asdf direnv hook asdf' command which was removed in asdf-direnv 0.3.0.
 
 You might want to run 'asdf direnv setup' again. See the README for instructions on updating.
 


### PR DESCRIPTION
Some old `< 0.3.0 release` commands now show a deprecation notice along with instructions on how to upgrade and run the new `asdf direnv setup` command. We also instruct users to manually remove the old direnv integration from `~/.config/direnv/direnvrc` since it was previously part of our manual instructions.

Fixes #146 