### PR TITLE
Ensure cached env file does *not* get created when there are errors

### DIFF
--- a/lib/commands/command-envrc.bash
+++ b/lib/commands/command-envrc.bash
@@ -5,9 +5,9 @@ set -Eeuo pipefail
 # shellcheck source=lib/tools-environment-lib.bash
 source "$(dirname "${BASH_SOURCE[0]}")/../tools-environment-lib.bash"
 
-if ! env_file="$(_asdf_cached_envrc "$@")"; then
+function print_generic_error() {
   log_error "Error generating asdf cached envrc"
-  exit 1
-fi
+}
+trap print_generic_error ERR
 
-echo "$env_file"
+_print_asdf_cached_envrc "$@"

--- a/lib/commands/command-envrc.bash
+++ b/lib/commands/command-envrc.bash
@@ -5,9 +5,4 @@ set -Eeuo pipefail
 # shellcheck source=lib/tools-environment-lib.bash
 source "$(dirname "${BASH_SOURCE[0]}")/../tools-environment-lib.bash"
 
-function print_generic_error() {
-  log_error "Error generating asdf cached envrc"
-}
-trap print_generic_error ERR
-
 _print_asdf_cached_envrc "$@"

--- a/lib/tools-environment-lib.bash
+++ b/lib/tools-environment-lib.bash
@@ -89,8 +89,8 @@ _cache_dir() {
   echo "$dir"
 }
 
-_asdf_cached_envrc() {
-  local dump_dir tools_file tools_cksum env_file
+_print_asdf_cached_envrc() {
+  local dump_dir tools_file tools_cksum
   dump_dir="$(_cache_dir)/env"
   generating_dump_dir="$(_cache_dir)/env-generating"
   tools_file="$(_local_versions_file)"
@@ -116,7 +116,6 @@ _asdf_cached_envrc() {
   generating_env_file="$(mktemp "$generating_dump_dir/$tools_cksum.XXXX")"
   _asdf_envrc "$tools_file" | _no_dups >"${generating_env_file}"
   mv "${generating_env_file}" "${env_file}"
-
   echo "$env_file"
 }
 

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -28,6 +28,7 @@ env_setup() {
   XDG_CACHE_HOME="$HOME/.cache"
   ASDF_DIR="$HOME/.asdf"
   ASDF_DATA_DIR="$ASDF_DIR"
+  EMPTY_DIR=$(mktemp -dt asdf.XXXX)
 
   # A temporary "system" direnv binary outside of asdf.
   DIRENV_SYS=$(mktemp -dt direnv.XXXX)
@@ -60,7 +61,7 @@ env_setup() {
 }
 
 env_teardown() {
-  rm -rf "$BASE_DIR"
+  rm -rf "$BASE_DIR" "$EMPTY_DIR"
   unset ASDF_CONCURRENCY
 }
 
@@ -69,6 +70,15 @@ envrc_load() {
   eval "$(direnv export bash)"
   direnv status
   cat .envrc
+}
+
+envrc_unload() {
+  # Simulate someone leaving a directory and direnv unloading by cd-ing into an
+  # empty directory and loading a `direnv export` (it's smart enough to unset
+  # environment variables as needed).
+  cd "$EMPTY_DIR" || exit 1
+  eval "$(direnv export bash)"
+  cd - || exit 1
 }
 
 dummy_bin_path() {


### PR DESCRIPTION
NOTE: There are a few commits from https://github.com/asdf-community/asdf-direnv/pull/157 in this PR. They will go away once https://github.com/asdf-community/asdf-direnv/pull/157 is merged up.

This fixes https://github.com/asdf-community/asdf-direnv/issues/156

For some reason, it was super hard for me to write a reliable test of
this, but I'm happy with where I landed.

I'm not so happy with the implementation: I couldn't figure out any
clean way of doing this with command substitution. I think the problem is that
[command substitution screws up `set -e` semantics], but we also rely
upon those semantics throughout so much of our codebase it didn't feel
reasonable to me to try to change all those places. But, it's hard to
get rid of command substitution: it's how we return useful values from
bash functions! Alternatives include:

- [namerefs]: This works, but requires Bash 4.3+, and macOS is stuck on
  some ancient 3.x version of bash.
- [clever dynamic scoping]

An alternative would be to keep using command substitution, but rework
things so that we're still invoking an actual bash script (rather than a
bash function) with our command substitution, and that child bash script
can run with full `set -e` semantics. That's how this all worked before
https://github.com/asdf-community/asdf-direnv/commit/6610b47515ef011d08f996fdf90280f7980fa4b7.

I went with something simple: I'm just calling `_asdf_cached_envrc`
directly, and letting it print the cached file path for us.
Unfortunately, `if` and other constructs like `||` [also don't preserve
errexit semantics], so I added a trap just to make sure we can still
print a nice "Error generating asdf cached envrc" message in case
something goes wrong and there's no obvious other thing that gets
printed.

I don't know if I'm overcomplicating things, I've been looking at this
too long to know. I think this whole mess is why some people suggest
[just discarding `set -e` in favor of handling this yourself][discarding set -e].

[command substitution screws up `set -e` semantics]: https://fvue.nl/wiki/Bash:_Error_handling#Caveat_3:_.60Exit_on_error.27_not_exitting_command_substition_on_error
[namerefs]: https://stackoverflow.com/a/52678279/1739415
[clever dynamic scoping]: https://stackoverflow.com/a/52082137/1739415
[also don't preserve errexit semantics]: https://stackoverflow.com/a/29540745/1739415
[discarding set -e]: https://mywiki.wooledge.org/BashFAQ/105#Conclusions