### PR TITLE
Keep brew available on Ubuntu

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -66,20 +66,23 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install shellcheck
-        run: brew install shellcheck
+        run: sudo apt-get install -y shellcheck
 
       - name: Run ShellCheck
         run: make lint
 
   format:
-    runs-on: ubuntu-latest
+    # ubuntu-latest is still pinned to Ubuntu 20, which doesn't have `shfmt`
+    # available to easily install.
+    # TODO: switch back to ubuntu-latest once Ubuntu 22 is the default.
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
       - name: Install shfmt
-        run: brew install shfmt
+        run: sudo apt-get install -y shfmt
 
       - name: Run shfmt
         run: make fmt-check

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -65,24 +65,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
       - name: Install shellcheck
-        run: sudo apt-get install -y shellcheck
+        run: brew install shellcheck
 
       - name: Run ShellCheck
         run: make lint
 
   format:
-    # ubuntu-latest is still pinned to Ubuntu 20, which doesn't have `shfmt`
-    # available to easily install.
-    # TODO: switch back to ubuntu-latest once Ubuntu 22 is the default.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
       - name: Install shfmt
-        run: sudo apt-get install -y shfmt
+        run: brew install shfmt
 
       - name: Run shfmt
         run: make fmt-check


### PR DESCRIPTION
I tried to switch us to `apt`, but that got messy: GitHub's `ubuntu-latest` currently points at `Ubuntu 20`, which doesn't have shfmt. We can opt into their [`ubuntu-22.04` beta](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/), which does have `shfmt`, but the versions of `shfmt` and `shellcheck` are old enough that they aren't happy with how our code is currently written. So, I broke down and used this [`setup-homebrew` action](https://github.com/Homebrew/actions/tree/master/setup-homebrew) to get brew available and give us the latest versions of these tools.

This fixes https://github.com/asdf-community/asdf-direnv/issues/160