### PR TITLE
Fix setup error with asdf v0.11

### DIFF
--- a/lib/setup-lib.bash
+++ b/lib/setup-lib.bash
@@ -116,7 +116,7 @@ function installed_direnv() {
       ;;
     latest | LATEST)
       run_cmd asdf install direnv latest
-      version="$(asdf list direnv | tail -n 1 | sed -e 's/ //g')" # since `ASDF_DIRENV_VERSION=latest asdf which direnv` does not work
+      version="$(asdf list direnv | tail -n 1 | sed -e 's/[ *]//g')" # since `ASDF_DIRENV_VERSION=latest asdf which direnv` does not work
       ASDF_DIRENV_BIN="$(run_cmd env ASDF_DIRENV_VERSION="$version" asdf which direnv)"
 
       ;;


### PR DESCRIPTION
## Overview

`asdf` v0.11.0 prepends `*` to the currently used version in the output of `asdf list <plugin>` like below.  
```
$ asdf list direnv
  2.32.1
 *2.32.2
```

So when `--version latest` is given, `installed_direnv()` function looks for a version prepended with `*` and fails.
```
$ asdf direnv setup --shell fish --version latest
Checking for asdf...
✔️  Found asdf at /home/toraja/.asdf/bin/asdf
Checking for direnv...
▶ asdf install direnv latest # ...  direnv 2.32.2 is already installed
✔️
▶ env ASDF_DIRENV_VERSION=*2.32.2 asdf which direnv # ...  No preset version installed for command direnv
Please install a version by running one of the following:

asdf install direnv *2.32.2

or add one of the following versions in your config file at /home/toraja/.tool-versions
direnv 2.32.1
direnv 2.32.2
❗️ Failed with status 1
❌  No direnv executable found
```