### PR TITLE
Fix instructions for generating debug info

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ watch_file "package.json"
 - Using a non-empty `ASDF_DIRENV_DEBUG` will enable bash-tracing with `set -x` and skip env-cache.
 
   For example, if you are troubleshooting or trying to debug something weird on
-  your environment, use `env ASDF_DIRENV_DEBUG=true direnv reload` and provide any
+  your environment, use `export ASDF_DIRENV_DEBUG=true; direnv reload` and provide any
   relevant output on an [issue](issues/new).
 
   Also, if you are contributing a new feature or bug-fix try running


### PR DESCRIPTION
We added these instructions in
https://github.com/asdf-community/asdf-direnv/commit/d8067b6f783411035182dad0c004095f6afab68f, but it looks like they never actually worked.

I think the reason this didn't work is because the `direnv reload` process isn't the one to actually re-read the `.envrc` file, it just pokes some direnv internals such that the shell intergration will re-read it, and if your shell doesn't have this environment variable set, then debugging just won't get turned on.

Proof that env vars for the `direnv reload` process don't actually make it to the `.envrc` file:

Setup:

    $ echo 'echo FOO IS ${FOO-}' > .envrc
    direnv: error /home/jeremy/tmp/demo/.envrc is blocked. Run `direnv allow` to approve its content
    $ direnv allow
    direnv: loading ~/tmp/demo/.envrc
    FOO IS

Now try reloading with a `FOO` env var only set for the `direnv reload` process. Note how it doesn't show up:

    $ env FOO=foo direnv reload
    direnv: loading ~/tmp/demo/.envrc
    FOO IS

Now set a `FOO` env var in your shell and reload. Not how it shows up when the `.envrc` gets executed:

    $ export FOO=foo

    $ direnv reload
    direnv: loading ~/tmp/demo/.envrc
    FOO IS foo
