### PR TITLE
Fix resolution of `latest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ github compare-link with the previous one.
 ## [Unreleased](https://github.com/asdf-community/asdf-direnv/compare/v0.3.0..master)
 
 - Add support for resolving 'latest:X' in .tool-versions #136
+- Add support for resolving 'latest' in .tool-versions #168
 
 ## [0.3.0](https://github.com/asdf-community/asdf-direnv/compare/v0.3.0) (2022-04-03)
 
@@ -27,7 +28,7 @@ github compare-link with the previous one.
 
 - Speed up direnv stdlib by trying not to use asdf exec. #120
 
-- Do not add plugin paths for "system" versions. #116 
+- Do not add plugin paths for "system" versions. #116
 
 
 ## [0.2.0](https://github.com/asdf-community/asdf-direnv/releases/v0.2.0) (2022-03-16)

--- a/lib/tools-environment-lib.bash
+++ b/lib/tools-environment-lib.bash
@@ -65,20 +65,32 @@ _follow_symlink() {
   echo "$(pwd -P)/$filename"
 }
 
-_load_asdf_utils() {
-  if [ -z "$(declare -f -F with_plugin_env)" ]; then
+_load_asdf_lib() {
+  local expected_function
+  local path
+  expected_function=$1
+  path=$2
+  if [ -z "$(declare -f -F "$expected_function")" ]; then
     ASDF_DIR="${ASDF_DIR:-"$(_follow_symlink "$(type -P asdf)" | xargs dirname | xargs dirname)"}"
     # libexec is a Homebrew specific thing. See
     # https://github.com/asdf-community/asdf-direnv/issues/95 for details.
     local lib_file
-    lib_file=$(ls "$ASDF_DIR"/{lib,libexec/lib}/utils.bash 2>/dev/null || true)
+    lib_file=$(ls "$ASDF_DIR"/{lib,libexec/lib}/"$path" 2>/dev/null || true)
     if [ ! -f "$lib_file" ]; then
-      log_error "Could not find asdf utils.bash file in $ASDF_DIR"
+      log_error "Could not find asdf $path file in $ASDF_DIR"
       return 1
     fi
     # shellcheck source=/dev/null # we don't want shellcheck trying to find this file
     source "$lib_file"
   fi
+}
+
+_load_asdf_utils() {
+  _load_asdf_lib with_plugin_env utils.bash
+}
+
+_load_asdf_functions_versions() {
+  _load_asdf_lib latest_command functions/versions.bash
 }
 
 _cache_dir() {
@@ -265,14 +277,19 @@ _plugin_env_bash() {
 
   local version
 
-  # The full_version may be of the form `latest:X`, so we resolve the latest
-  # version here. This is the same method asdf itself uses; see
-  # https://github.com/asdf-vm/asdf/blob/7493f4099c844e40af72d7f05635d7991a463d1a/lib/commands/command-install.bash#L161
+  # The full_version may be of the form `latest:X` or just `latest`, so we
+  # resolve the latest version here. This is the same method asdf itself uses;
+  # see
+  # https://github.com/asdf-vm/asdf/blob/a91b6d0ee3bc87af0af3cd4b29dd74695e8026b8/lib/functions/versions.bash#L40-L48
+  _load_asdf_functions_versions
   IFS=':' read -r -a version_info <<<"$full_version"
-  if [ "${version_info[0]}" = "latest" ]; then
-    version=$(asdf latest "$plugin" "${version_info[1]}")
+  if [ "${version_info[0]}" = "latest" ] && [ -n "${version_info[1]-}" ]; then
+    version=$(latest_command "$plugin_name" "${version_info[1]}")
+  elif [ "${version_info[0]}" = "latest" ] && [ -z "${version_info[1]-}" ]; then
+    version=$(latest_command "$plugin_name" "")
   else
-    version="${version_info[0]}"
+    # if branch handles ref: || path: || normal versions
+    version="$full_version"
   fi
 
   local install_path

--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -163,7 +163,28 @@ EOF
 
   cd "$PROJECT_DIR"
   asdf global dummy 2.0
-  asdf local dummy latest:2
+  # Note: we're writing directly to .tool-versions rather than using `asdf
+  # local dummy latest:2` because that `asdf local` command will actually
+  # resolve the appropriate vresion rather than putting the unresolved version
+  # in the .tool-versions file.
+  echo "dummy latest:2" >.tool-versions
+  asdf direnv local
+  envrc_load
+
+  run dummy
+  [ "$output" == "This is dummy 2.1" ] # executable in path
+}
+
+@test "use asdf - resolves latest version from tool-versions" {
+  install_dummy_plugin dummy 2.0
+  install_dummy_plugin dummy 2.1
+
+  cd "$PROJECT_DIR"
+  # Note: we're writing directly to .tool-versions rather than using `asdf
+  # local dummy latest` because that `asdf local` command will actually
+  # resolve the appropriate vresion rather than putting the unresolved version
+  # in the .tool-versions file.
+  echo "dummy latest" >.tool-versions
   asdf direnv local
   envrc_load
 


### PR DESCRIPTION
This fixes https://github.com/asdf-community/asdf-direnv/issues/159

A while back [we added support for
`latest:X`](https://github.com/asdf-community/asdf-direnv/commit/1c12032ffa1023e12effa193e918561d6554515f), but I don't think we ever verified if this worked for just plain `latest`. This copies the latest code from upstream, which requires importing the `latest_command` command from asdf itself.
