### PR TITLE
Fix warning on find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ github compare-link with the previous one.
 
 ## [Unreleased](https://github.com/asdf-community/asdf-direnv/compare/v0.3.0..master)
 
+- Fix `find` warning. #178
 - Add '--no-touch-rc-file' option to prevent rc file modification during updates. #176
 - Alternatively, `export ASDF_DIRENV_NO_TOUCH_RC_FILE=1` to prevent rc file modification. #176
 

--- a/lib/tools-environment-lib.bash
+++ b/lib/tools-environment-lib.bash
@@ -189,7 +189,7 @@ _plugins_in_file() {
 
 _all_plugins_list() {
   # NOTE: passing empty to `get_plugin_path` yields the plugins root.
-  find "$(get_plugin_path "")" ! -name '.DS_Store' -maxdepth 1 -mindepth 1 -exec basename '{}' \;
+  find "$(get_plugin_path "")" -maxdepth 1 -mindepth 1 ! -name '.DS_Store' -exec basename '{}' \;
 }
 
 _except_local_plugins_list() {


### PR DESCRIPTION
## Overview

Fixes the following warning occurring since #177:

```text
direnv: loading ~/somedir/.envrc
direnv: using asdf
direnv: Creating env file /Users/foo/.cache/asdf-direnv/env/2102687569-1439381117-3323426503-1825845895
find: warning: you have specified the global option -maxdepth after the argument !, but global options are not positional, i.e., -maxdepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
find: warning: you have specified the global option -mindepth after the argument !, but global options are not positional, i.e., -mindepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
```

## Test coverage

> Have you included tests (which could be a transcript) for this change, or is it somehow covered by existing tests?
> Would you recommend improving the test coverage (either as part of this PR or as a separate issue) or do you think it’s adequate?

No, could use a test that ensures the `find` warning doesn't appear in stderr, run with both GNU and BSD-like `find`.  Assuming the latter seems to be the problem with the original line.