### PR TITLE
Appease shellcheck

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -48,12 +48,12 @@ jobs:
 
       - name: Install bats-core
         run: |
-          git clone --depth 1 --branch v1.6.0 https://github.com/bats-core/bats-core.git $HOME/bats-core
+          git clone --depth 1 --branch v1.6.0 https://github.com/bats-core/bats-core.git "$HOME/bats-core"
           echo "$HOME/bats-core/bin" >>"$GITHUB_PATH"
 
       - name: Run tests
         run: |
-          asdf plugin-add direnv $GITHUB_WORKSPACE
+          asdf plugin-add direnv "$GITHUB_WORKSPACE"
           asdf install direnv ${{ matrix.direnv }}
           asdf global direnv ${{ matrix.direnv }}
           make test


### PR DESCRIPTION
We use actionlint, which (among other things) runs shellcheck against the steps of our workflows. shellcheck doesn't like these variable references without surrounding double quotes. While I doubt either of these will ever contain a space, it's easier to just add the quotes to make shellcheck happy.