### PR TITLE
Support "ref:" and "path:" versions in .tool-versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ github compare-link with the previous one.
 
 ## [Unreleased](https://github.com/asdf-community/asdf-direnv/compare/v0.3.0..master)
 
-- Support `ref:tag/commit/brach` and `path:~/local-tool-version` versions in `.tool-versions`
+- Support `ref:tag/branch/commit` and `path:/local/tool/version` versions in `.tool-versions`
   file. #188
 
 - Add new `asdf direnv install` command to help when installing tools that depend on each other. #180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ github compare-link with the previous one.
 
 ## [Unreleased](https://github.com/asdf-community/asdf-direnv/compare/v0.3.0..master)
 
+- Support `ref:tag/commit/brach` and `path:~/local-tool-version` versions in `.tool-versions`
+  file. #188
+
 - Add new `asdf direnv install` command to help when installing tools that depend on each other. #180
 
 - Fix `find` warning. #178

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SH_SRCFILES = $(shell git ls-files "bin/*" "*.bash" "*.bats")
 SHFMT_BASE_FLAGS = -s
 
-all: test lint fmt-check
+all: test lint fmt format-check
 
 .PHONY: all
 

--- a/lib/tools-environment-lib.bash
+++ b/lib/tools-environment-lib.bash
@@ -286,7 +286,6 @@ _plugin_env_bash() {
   local not_installed_message="${3}"
   local ignore_missing_plugins="${ASDF_DIRENV_IGNORE_MISSING_PLUGINS:-0}"
 
-  # NOTE: unlike asdf, asdf-direnv does not support other installation types.
   local install_type="version"
 
   plugin_path=$(get_plugin_path "$plugin")
@@ -312,8 +311,13 @@ _plugin_env_bash() {
     version=$(latest_command "$plugin_name" "${version_info[1]}")
   elif [ "${version_info[0]}" = "latest" ] && [ -z "${version_info[1]-}" ]; then
     version=$(latest_command "$plugin_name" "")
+  elif [ "${version_info[0]}" = "ref" ]; then
+    install_type="${version_info[0]}"
+    version="${version_info[1]}"
+  elif [ "${version_info[0]}" = "path" ]; then
+    install_type="${version_info[0]}"
+    version="${version_info[1]}"
   else
-    # if branch handles ref: || path: || normal versions
     version="$full_version"
   fi
 

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -84,6 +84,8 @@ envrc_unload() {
 dummy_bin_path() {
   local plugin_name="${1:-dummy}"
   local version="${2:-'1.0'}"
+  # shellcheck disable=SC2001
+  version=$(echo "$version" | sed 's/^ref:/ref-/')
   echo "$ASDF_DATA_DIR/installs/${plugin_name}/${version}/bin"
 }
 

--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -372,7 +372,7 @@ EOF
   asdf direnv local dummy ref:v1.0
 
   asdf direnv local
-  run envrc_load
+  envrc_load
 
   run asdf exec dummy
   [ "$output" == "This is dummy ref:v1.0" ]

--- a/test/use_asdf.bats
+++ b/test/use_asdf.bats
@@ -365,3 +365,31 @@ EOF
 
   echo "$output" | grep "direnv: ignoring not installed plugin: missing"
 }
+
+@test "use asdf - resolves ref:version" {
+  install_dummy_plugin "dummy" "ref:v1.0"
+
+  asdf direnv local dummy ref:v1.0
+
+  asdf direnv local
+  run envrc_load
+
+  run asdf exec dummy
+  [ "$output" == "This is dummy ref:v1.0" ]
+}
+
+@test "use asdf - resolves path:version" {
+  install_dummy_plugin
+
+  echo "dummy path:~/src/dummy" >>.tool-versions
+
+  mkdir -p ~/src/dummy/bin
+  echo "echo This is dummy path" >~/src/dummy/bin/dummy
+  chmod +x ~/src/dummy/bin/dummy
+
+  asdf direnv local
+  envrc_load
+
+  run asdf exec dummy
+  [ "$output" == "This is dummy path" ]
+}


### PR DESCRIPTION
## Overview

This change is to support the use of `ref:tag/branch/commit` and `path:/local/tool/version` tool versions.

Before: 😞 
![image](https://github.com/asdf-community/asdf-direnv/assets/4416345/9793a5e3-6084-4e12-a7e5-419f77790e35)

After: 🥳 
![image](https://github.com/asdf-community/asdf-direnv/assets/4416345/b9bd15eb-8d10-4b5b-9f2b-55dbd19ffcf4)

## Implementation notes

The code replicates the `list_plugin_exec_paths()` behaviour from [`.asdf/lib/utils.bash`](https://github.com/asdf-vm/asdf/blob/ccdd47df9b73d0a22235eb06ad4c48eb57360832/lib/utils.bash#L534-L545) and integrates it into the `_plugin_env_bash()` version-resolution block.

## Interesting/controversial decisions

Fixed Makefile target names.

Note the change in test helper also disables shellcheck SC2001 because we're matching the start of the string, which is not possible in a simple substitution.

## Test coverage

The new tests cover both version types, with a necessary change to `dummy_bin_path()` to match the directory naming that's generated in [get_install_path()](https://github.com/asdf-vm/asdf/blob/ccdd47df9b73d0a22235eb06ad4c48eb57360832/lib/utils.bash#L72) and reversed in [list_installed_versions()](https://github.com/asdf-vm/asdf/blob/ccdd47df9b73d0a22235eb06ad4c48eb57360832/lib/utils.bash#L106-L107).

## Loose ends

Testing with dummy shims?