### PR TITLE
Fix macOS build: upgrade to latest direnv

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,7 +31,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         direnv:
-          - 2.23.1
+          - 2.34.0
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
A few months ago, our GitHub actions started running on arm macOS
machines [0]. However, direnv v2.23.1 doesn't actually have an arm
release for macos:
https://github.com/direnv/direnv/releases/tag/v2.23.1. direnv started
uploading prebuild darwin-amd64 images in v2.28.0:
https://github.com/direnv/direnv/releases/tag/v2.28.0. I opted to just
upgrade us to the latest version while I'm in here.

[0]: https://www.reddit.com/r/github/comments/1cjiat4/is_github_actions_macoslatest_now_only_armbased/
